### PR TITLE
feat: Redesign dashboard Get Started experience

### DIFF
--- a/app/dashboard/insights/page.tsx
+++ b/app/dashboard/insights/page.tsx
@@ -35,6 +35,7 @@ import type {
 } from "@/lib/types/insights";
 
 export default function InsightsDashboardPage() {
+  useEffect(() => { localStorage.setItem("sahara_features_explored", "true"); }, []);
   const [abTests, setAbTests] = useState<ABTestResult[]>([]);
   const [analytics, setAnalytics] = useState<AIAnalytics | null>(null);
   const [topInsights, setTopInsights] = useState<TopInsight[]>([]);

--- a/app/dashboard/journey/page.tsx
+++ b/app/dashboard/journey/page.tsx
@@ -71,6 +71,7 @@ interface TimelineEvent {
 }
 
 export default function JourneyDashboard() {
+  useEffect(() => { localStorage.setItem("sahara_features_explored", "true"); }, []);
   const [isAddMilestoneOpen, setIsAddMilestoneOpen] = useState(false);
   const [insights, setInsights] = useState<Insight[]>([]);
   const [milestones, setMilestones] = useState<Milestone[]>([]);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,7 +7,7 @@ import { createClient } from "@/lib/supabase/client";
 import { useTier } from "@/lib/context/tier-context";
 import { toast } from "sonner";
 import { WelcomeModal } from "@/components/dashboard/WelcomeModal";
-import { OnboardingChecklist } from "@/components/dashboard/onboarding-checklist";
+import { GetStartedWithFred } from "@/components/dashboard/get-started-with-fred";
 import { RedFlagsWidget } from "@/components/dashboard/red-flags-widget";
 import { FounderSnapshotCard } from "@/components/dashboard/founder-snapshot-card";
 import { DecisionBox } from "@/components/dashboard/decision-box";
@@ -145,25 +145,7 @@ function DashboardContent() {
             Your Founder Command Center
           </p>
         </div>
-        <OnboardingChecklist />
-        <div className="rounded-2xl border-2 border-[#ff6a1a]/30 bg-gradient-to-br from-[#ff6a1a]/5 to-orange-50 dark:from-[#ff6a1a]/10 dark:to-gray-900 p-8 text-center">
-          <div className="w-16 h-16 mx-auto mb-4 rounded-2xl bg-gradient-to-br from-[#ff6a1a] to-orange-500 flex items-center justify-center shadow-lg shadow-[#ff6a1a]/25">
-            <MessageSquare className="w-8 h-8 text-white" />
-          </div>
-          <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
-            Start by talking to Fred
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400 mb-6 max-w-md mx-auto">
-            Fred will ask you the right questions to understand your startup and build your personalized command center.
-          </p>
-          <a
-            href="/chat"
-            className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-[#ff6a1a] hover:bg-[#ea580c] text-white font-semibold text-base transition-colors shadow-lg shadow-[#ff6a1a]/25 hover:shadow-[#ff6a1a]/40"
-          >
-            Talk to Fred
-            <ArrowRight className="w-5 h-5" />
-          </a>
-        </div>
+        <GetStartedWithFred />
         <WelcomeModal
           isOpen={showWelcome}
           onClose={handleCloseWelcome}
@@ -196,8 +178,8 @@ function DashboardContent() {
         )}
       </div>
 
-      {/* Onboarding Checklist (dismissible) */}
-      <OnboardingChecklist />
+      {/* Get Started with Fred (auto-hides when core steps complete) */}
+      <GetStartedWithFred />
 
       {/* Work with Fred CTA — prominent for all users */}
       <a

--- a/app/dashboard/reality-lens/page.tsx
+++ b/app/dashboard/reality-lens/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -76,6 +76,7 @@ interface ApiResponse {
 // ---------------------------------------------------------------------------
 
 export default function RealityLensPage() {
+  useEffect(() => { localStorage.setItem("sahara_features_explored", "true"); }, []);
   const [idea, setIdea] = useState("");
   const [stage, setStage] = useState<string>("");
   const [market, setMarket] = useState("");

--- a/components/dashboard/get-started-with-fred.tsx
+++ b/components/dashboard/get-started-with-fred.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import Link from "next/link";
+import { useTier } from "@/lib/context/tier-context";
+import { useGetStartedSteps, type GetStartedStep } from "@/lib/hooks/use-get-started-steps";
+import { cn } from "@/lib/utils";
+
+function CheckIcon() {
+  return (
+    <svg className="h-5 w-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}
+
+function StepCircle({ step, isNext }: { step: GetStartedStep; isNext: boolean }) {
+  if (step.completed) {
+    return (
+      <div className="h-7 w-7 rounded-full bg-green-500 flex items-center justify-center shrink-0">
+        <CheckIcon />
+      </div>
+    );
+  }
+
+  if (step.isOptional) {
+    return (
+      <div className={cn(
+        "h-7 w-7 rounded-full flex items-center justify-center shrink-0 border-2",
+        "border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500"
+      )}>
+        <svg className="h-4 w-4" fill="currentColor" viewBox="0 0 20 20">
+          <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+        </svg>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn(
+      "h-7 w-7 rounded-full flex items-center justify-center shrink-0 text-sm font-bold border-2",
+      isNext
+        ? "border-[#ff6a1a] bg-[#ff6a1a]/10 text-[#ff6a1a]"
+        : "border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500"
+    )}>
+      {String(step.number)}
+    </div>
+  );
+}
+
+function StepRow({
+  step,
+  isNext,
+  isMobile,
+}: {
+  step: GetStartedStep;
+  isNext: boolean;
+  isMobile: boolean;
+}) {
+  return (
+    <div className={cn(
+      "flex items-start gap-3 py-3",
+      isMobile && "flex-col gap-2"
+    )}>
+      <div className={cn("flex items-start gap-3 flex-1 min-w-0", isMobile && "w-full")}>
+        <StepCircle step={step} isNext={isNext} />
+        <div className="flex-1 min-w-0">
+          <p className={cn(
+            "text-sm font-medium leading-snug",
+            step.completed
+              ? "text-gray-400 dark:text-gray-500"
+              : isNext
+                ? "text-gray-900 dark:text-white font-semibold"
+                : "text-gray-700 dark:text-gray-300"
+          )}>
+            {step.label}
+          </p>
+          <p className={cn(
+            "text-xs mt-0.5 leading-relaxed",
+            step.completed
+              ? "text-gray-400 dark:text-gray-600"
+              : "text-gray-500 dark:text-gray-400"
+          )}>
+            {step.description}
+          </p>
+        </div>
+      </div>
+
+      {/* CTA / Status */}
+      <div className={cn("shrink-0", isMobile && "w-full pl-10")}>
+        {step.completed ? (
+          <span className="text-xs font-medium text-green-600 dark:text-green-400">
+            {step.isOptional && step.completed ? "Unlocked" : "Done"}
+          </span>
+        ) : (
+          <Link
+            href={step.href}
+            className={cn(
+              "inline-flex items-center justify-center text-xs font-semibold rounded-lg px-3 py-1.5 transition-colors",
+              isNext
+                ? "bg-[#ff6a1a] hover:bg-[#ea580c] text-white shadow-sm"
+                : step.isOptional
+                  ? "bg-gray-100 hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300"
+                  : "bg-[#ff6a1a]/10 hover:bg-[#ff6a1a]/20 text-[#ff6a1a]",
+              isMobile && "w-full py-2"
+            )}
+          >
+            {step.cta}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function GetStartedWithFred({
+  variant = "desktop",
+}: {
+  variant?: "desktop" | "mobile";
+}) {
+  const { tier } = useTier();
+  const { steps, completedCount, coreStepCount, allCoreComplete, isLoading } =
+    useGetStartedSteps(tier);
+
+  // Auto-hide when all 3 core steps are complete
+  if (allCoreComplete || isLoading) return null;
+
+  const isMobile = variant === "mobile";
+  const progressPercent = Math.round((completedCount / coreStepCount) * 100);
+  const coreSteps = steps.filter((s) => !s.isOptional);
+  const optionalSteps = steps.filter((s) => s.isOptional);
+
+  // Find the first incomplete core step
+  const nextStepId = coreSteps.find((s) => !s.completed)?.id;
+
+  return (
+    <div className={cn(
+      "rounded-2xl border-2 border-[#ff6a1a]/30 bg-gradient-to-br from-[#ff6a1a]/5 to-orange-50/50 dark:from-[#ff6a1a]/10 dark:to-gray-900/50 overflow-hidden",
+      isMobile ? "p-4" : "p-6"
+    )}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <span className="text-lg" role="img" aria-label="rocket">
+            &#x1F680;
+          </span>
+          <h3 className={cn(
+            "font-bold text-gray-900 dark:text-white",
+            isMobile ? "text-base" : "text-lg"
+          )}>
+            Get Started with Fred
+          </h3>
+        </div>
+        <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+          {completedCount} of {coreStepCount} done
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden mb-4">
+        <div
+          className="h-full rounded-full bg-gradient-to-r from-[#ff6a1a] to-orange-400 transition-all duration-500 ease-out"
+          style={{ width: `${progressPercent}%` }}
+        />
+      </div>
+
+      {/* Core steps */}
+      <div className="divide-y divide-gray-200/60 dark:divide-gray-700/60">
+        {coreSteps.map((step) => (
+          <StepRow
+            key={step.id}
+            step={step}
+            isNext={step.id === nextStepId}
+            isMobile={isMobile}
+          />
+        ))}
+      </div>
+
+      {/* Separator */}
+      <div className="my-3 border-t-2 border-dashed border-gray-200 dark:border-gray-700" />
+
+      {/* Optional steps */}
+      <div className="opacity-75">
+        {optionalSteps.map((step) => (
+          <StepRow
+            key={step.id}
+            step={step}
+            isNext={false}
+            isMobile={isMobile}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/mobile/mobile-home.tsx
+++ b/components/mobile/mobile-home.tsx
@@ -14,6 +14,7 @@ import {
   AlertCircle,
   Lock,
 } from "lucide-react";
+import { GetStartedWithFred } from "@/components/dashboard/get-started-with-fred";
 import { cn } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
 import { useTier } from "@/lib/context/tier-context";
@@ -149,19 +150,7 @@ export function MobileHome() {
             Your Founder Command Center
           </p>
         </div>
-        <Card className="border-gray-200 dark:border-gray-800">
-          <CardContent className="p-6 text-center">
-            <p className="text-gray-500 dark:text-gray-400 mb-4">
-              Start a conversation with FRED to populate your command center.
-            </p>
-            <Link href="/dashboard/chat">
-              <Button className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white">
-                <MessageSquare className="mr-2 h-4 w-4" />
-                Talk to FRED
-              </Button>
-            </Link>
-          </CardContent>
-        </Card>
+        <GetStartedWithFred variant="mobile" />
       </div>
     );
   }
@@ -177,6 +166,9 @@ export function MobileHome() {
           Here is what matters today.
         </p>
       </div>
+
+      {/* Get Started with Fred */}
+      <GetStartedWithFred variant="mobile" />
 
       {/* Today's Focus -- most important decision */}
       <TodaysFocus

--- a/lib/hooks/use-get-started-steps.ts
+++ b/lib/hooks/use-get-started-steps.ts
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { UserTier } from "@/lib/constants";
+
+const FEATURES_EXPLORED_KEY = "sahara_features_explored";
+
+export interface GetStartedStep {
+  id: string;
+  number: number | "*";
+  label: string;
+  description: string;
+  completed: boolean;
+  href: string;
+  cta: string;
+  isOptional?: boolean;
+}
+
+interface GetStartedState {
+  steps: GetStartedStep[];
+  completedCount: number;
+  coreStepCount: number;
+  allCoreComplete: boolean;
+  isLoading: boolean;
+}
+
+export function useGetStartedSteps(tier: UserTier): GetStartedState {
+  const [isLoading, setIsLoading] = useState(true);
+  const [profileComplete, setProfileComplete] = useState(false);
+  const [hasConversation, setHasConversation] = useState(false);
+  const [featuresExplored, setFeaturesExplored] = useState(false);
+
+  useEffect(() => {
+    // Check localStorage for features explored
+    setFeaturesExplored(
+      localStorage.getItem(FEATURES_EXPLORED_KEY) === "true"
+    );
+
+    async function fetchData() {
+      try {
+        const supabase = createClient();
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+
+        if (!user) {
+          setIsLoading(false);
+          return;
+        }
+
+        // Fetch profile and stats in parallel
+        const [profileRes, statsRes] = await Promise.all([
+          supabase
+            .from("profiles")
+            .select("stage, challenges")
+            .eq("id", user.id)
+            .single(),
+          fetch("/api/dashboard/stats"),
+        ]);
+
+        // Check profile completion: stage + challenges populated
+        if (profileRes.data) {
+          const { stage, challenges } = profileRes.data;
+          setProfileComplete(
+            Boolean(stage) && Boolean(challenges)
+          );
+        }
+
+        // Check conversation count from stats API
+        if (statsRes.ok) {
+          const json = await statsRes.json();
+          if (json.success && json.data) {
+            setHasConversation((json.data.ideasAnalyzed ?? 0) > 0);
+          }
+        }
+      } catch (e) {
+        console.error("Failed to fetch get-started data:", e);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchData();
+  }, []);
+
+  const coreSteps: GetStartedStep[] = [
+    {
+      id: "tell-fred",
+      number: 1,
+      label: "Tell Fred about your startup",
+      description:
+        "Fred gives better advice when he knows your stage and biggest challenge.",
+      completed: profileComplete,
+      href: "/onboarding",
+      cta: "Get Started",
+    },
+    {
+      id: "first-conversation",
+      number: 2,
+      label: "Have your first conversation with Fred",
+      description:
+        "Chat with Fred about any startup decision — strategy, fundraising, product, growth.",
+      completed: hasConversation,
+      href: "/chat",
+      cta: "Chat with Fred",
+    },
+    {
+      id: "explore-features",
+      number: 3,
+      label: "Explore what Fred can do",
+      description:
+        "Discover Reality Lens, decision tracking, and AI insights — all included free.",
+      completed: featuresExplored,
+      href: "/dashboard/reality-lens",
+      cta: "See Features",
+    },
+  ];
+
+  const optionalStep: GetStartedStep = {
+    id: "unlock-voice",
+    number: "*",
+    label: "Unlock voice calls & more",
+    description:
+      "Pro members can call Fred by voice. Studio adds weekly SMS check-ins.",
+    completed: tier >= UserTier.PRO,
+    href: "/pricing",
+    cta: tier >= UserTier.PRO ? "Unlocked" : "See Plans",
+    isOptional: true,
+  };
+
+  const steps = [...coreSteps, optionalStep];
+  const completedCount = coreSteps.filter((s) => s.completed).length;
+  const coreStepCount = coreSteps.length;
+  const allCoreComplete = completedCount === coreStepCount;
+
+  return {
+    steps,
+    completedCount,
+    coreStepCount,
+    allCoreComplete,
+    isLoading,
+  };
+}


### PR DESCRIPTION
## Summary
- Replaces the generic, dismissible `OnboardingChecklist` with a new `GetStartedWithFred` component
- 3 focused core steps (tell Fred about startup → first conversation → explore features) + 1 optional upgrade step
- Auto-hides when all 3 core steps complete — no dismiss button
- Shared between desktop and mobile views with responsive layout
- Feature pages (Reality Lens, Journey, Insights) now track exploration via localStorage

## Test plan
- [ ] New user (no data): Dashboard shows GetStartedWithFred with all 3 core steps unchecked
- [ ] Partial progress: After chatting with Fred, step 2 auto-completes
- [ ] All core complete: Component auto-hides, normal dashboard shows
- [ ] Pro+ user: Optional step 4 shows as "Unlocked"
- [ ] Mobile: Same steps, mobile-optimized layout
- [ ] Feature pages: Visiting reality-lens/journey/insights sets localStorage flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)