### PR TITLE
feat(goals): structured goal sets by funding stage

### DIFF
--- a/app/api/dashboard/goals/route.ts
+++ b/app/api/dashboard/goals/route.ts
@@ -1,0 +1,133 @@
+/**
+ * Goals API — Structured goal sets by funding stage
+ *
+ * GET   /api/dashboard/goals — List goals for the current user
+ * POST  /api/dashboard/goals — Generate goal set based on stage (idempotent)
+ * PATCH /api/dashboard/goals — Toggle goal completion
+ *
+ * Linear: AI-1283
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import {
+  getFounderGoals,
+  generateGoalSet,
+  toggleGoalComplete,
+  type FounderGoal,
+} from "@/lib/goals/goal-service";
+import { createServiceClient } from "@/lib/supabase/server";
+
+export async function GET() {
+  try {
+    const userId = await requireAuth();
+
+    let goals: FounderGoal[];
+    try {
+      goals = await getFounderGoals(userId);
+    } catch (dbError) {
+      console.warn("[Goals API] DB query failed, returning empty:", dbError);
+      goals = [];
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: goals,
+    });
+  } catch (error) {
+    if (error instanceof Response) return error;
+    console.error("[Goals API] GET error:", error);
+    return NextResponse.json({
+      success: true,
+      data: [],
+    });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await requireAuth();
+
+    // Optionally accept stage in the body; otherwise read from profile
+    let stage: string | null = null;
+    try {
+      const body = await request.json();
+      stage = body.stage || null;
+    } catch {
+      // No body — will read from profile
+    }
+
+    if (!stage) {
+      const supabase = createServiceClient();
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("stage")
+        .eq("id", userId)
+        .single();
+
+      stage = profile?.stage || null;
+    }
+
+    const force = false; // Don't overwrite by default
+    const goals = await generateGoalSet(userId, stage, { force });
+
+    return NextResponse.json({
+      success: true,
+      data: goals,
+    });
+  } catch (error) {
+    if (error instanceof Response) return error;
+    console.error("[Goals API] POST error:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to generate goals" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest) {
+  try {
+    const userId = await requireAuth();
+    const body = await request.json();
+
+    const { id, completed } = body as {
+      id?: string;
+      completed?: boolean;
+    };
+
+    if (!id) {
+      return NextResponse.json(
+        { success: false, error: "id is required" },
+        { status: 400 }
+      );
+    }
+
+    if (completed === undefined) {
+      return NextResponse.json(
+        { success: false, error: "completed is required" },
+        { status: 400 }
+      );
+    }
+
+    const goal = await toggleGoalComplete(userId, id, completed);
+
+    if (!goal) {
+      return NextResponse.json(
+        { success: false, error: "Goal not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: goal,
+    });
+  } catch (error) {
+    if (error instanceof Response) return error;
+    console.error("[Goals API] PATCH error:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to update goal" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ import { MomentumIndicator } from "@/components/dashboard/momentum-indicator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { MobileHome } from "@/components/mobile/mobile-home";
+import { GoalRoadmap } from "@/components/dashboard/goal-roadmap";
 import { FadeIn } from "@/components/animations/FadeIn";
 import { UserTier } from "@/lib/constants";
 import type { CommandCenterData } from "@/lib/dashboard/command-center";
@@ -161,6 +162,7 @@ function DashboardContent() {
           hasHadConversations={false}
         />
         <GetStartedWithFred />
+        <GoalRoadmap />
         <WelcomeModal
           isOpen={showWelcome}
           onClose={handleCloseWelcome}
@@ -184,6 +186,11 @@ function DashboardContent() {
       {/* Get Started checklist — only shows until core steps complete */}
       <FadeIn>
         <GetStartedWithFred />
+      </FadeIn>
+
+      {/* Goal Roadmap — structured milestones by funding stage */}
+      <FadeIn delay={0.05}>
+        <GoalRoadmap />
       </FadeIn>
 
       {/* Everything below is the OUTPUT of your Fred conversations */}

--- a/components/dashboard/goal-roadmap.tsx
+++ b/components/dashboard/goal-roadmap.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  CheckCircle2,
+  Circle,
+  Loader2,
+  Target,
+  ChevronDown,
+  ChevronUp,
+  Sparkles,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FounderGoal } from "@/lib/goals/goal-service";
+
+// ============================================================================
+// Category Config
+// ============================================================================
+
+const CATEGORY_CONFIG: Record<string, { label: string; color: string }> = {
+  validation: {
+    label: "Validation",
+    color: "text-purple-600 dark:text-purple-400",
+  },
+  product: {
+    label: "Product",
+    color: "text-blue-600 dark:text-blue-400",
+  },
+  growth: {
+    label: "Growth",
+    color: "text-green-600 dark:text-green-400",
+  },
+  fundraising: {
+    label: "Fundraising",
+    color: "text-[#ff6a1a]",
+  },
+  strategy: {
+    label: "Strategy",
+    color: "text-amber-600 dark:text-amber-400",
+  },
+};
+
+// ============================================================================
+// Goal Card
+// ============================================================================
+
+function GoalCard({
+  goal,
+  stepNumber,
+  isCurrentStep,
+  onToggle,
+}: {
+  goal: FounderGoal;
+  stepNumber: number;
+  isCurrentStep: boolean;
+  onToggle: (goalId: string, completed: boolean) => Promise<void>;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [optimisticCompleted, setOptimisticCompleted] = useState(goal.completed);
+  const categoryConfig = CATEGORY_CONFIG[goal.category] || CATEGORY_CONFIG.strategy;
+
+  async function handleToggle() {
+    const newState = !optimisticCompleted;
+    setOptimisticCompleted(newState);
+    setLoading(true);
+    try {
+      await onToggle(goal.id, newState);
+    } catch {
+      setOptimisticCompleted(!newState);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "relative flex items-start gap-4 py-4",
+        isCurrentStep && !optimisticCompleted && "bg-[#ff6a1a]/5 -mx-4 px-4 rounded-xl"
+      )}
+    >
+      {/* Step indicator */}
+      <div className="flex flex-col items-center gap-1 pt-0.5">
+        <button
+          onClick={handleToggle}
+          disabled={loading}
+          className={cn(
+            "flex-shrink-0 transition-all",
+            optimisticCompleted
+              ? "text-green-500 dark:text-green-400"
+              : isCurrentStep
+                ? "text-[#ff6a1a] hover:text-[#ea580c]"
+                : "text-gray-300 dark:text-gray-600 hover:text-gray-400"
+          )}
+        >
+          {loading ? (
+            <Loader2 className="h-6 w-6 animate-spin" />
+          ) : optimisticCompleted ? (
+            <CheckCircle2 className="h-6 w-6" />
+          ) : (
+            <Circle className="h-6 w-6" />
+          )}
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <span
+              className={cn(
+                "text-xs font-bold uppercase tracking-wider",
+                optimisticCompleted
+                  ? "text-gray-400 dark:text-gray-500"
+                  : isCurrentStep
+                    ? "text-[#ff6a1a]"
+                    : "text-gray-400 dark:text-gray-500"
+              )}
+            >
+              Step {stepNumber}
+            </span>
+            <span className={cn("text-xs font-medium", categoryConfig.color)}>
+              {categoryConfig.label}
+            </span>
+          </div>
+        </div>
+
+        <h4
+          className={cn(
+            "text-sm font-semibold mt-1 leading-snug",
+            optimisticCompleted
+              ? "line-through text-gray-400 dark:text-gray-500"
+              : "text-gray-900 dark:text-white"
+          )}
+        >
+          {goal.title}
+        </h4>
+
+        {/* Description toggle */}
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="mt-1 inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+        >
+          {expanded ? "Less" : "Details"}
+          {expanded ? (
+            <ChevronUp className="h-3 w-3" />
+          ) : (
+            <ChevronDown className="h-3 w-3" />
+          )}
+        </button>
+
+        {expanded && (
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+            {goal.description}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export function GoalRoadmap() {
+  const [goals, setGoals] = useState<FounderGoal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [generating, setGenerating] = useState(false);
+
+  const fetchGoals = useCallback(async () => {
+    try {
+      const res = await fetch("/api/dashboard/goals");
+      const json = await res.json();
+      if (json.success) {
+        setGoals(json.data || []);
+      }
+    } catch {
+      console.warn("[GoalRoadmap] Failed to fetch goals");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchGoals();
+  }, [fetchGoals]);
+
+  // Auto-generate goals if none exist
+  useEffect(() => {
+    if (!loading && goals.length === 0 && !generating) {
+      setGenerating(true);
+      fetch("/api/dashboard/goals", { method: "POST" })
+        .then((res) => res.json())
+        .then((json) => {
+          if (json.success && json.data?.length > 0) {
+            setGoals(json.data);
+          }
+        })
+        .catch(() => {
+          // Silently fail — table may not exist yet
+        })
+        .finally(() => setGenerating(false));
+    }
+  }, [loading, goals.length, generating]);
+
+  const handleToggle = useCallback(
+    async (goalId: string, completed: boolean) => {
+      try {
+        const res = await fetch("/api/dashboard/goals", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: goalId, completed }),
+        });
+        const json = await res.json();
+        if (!json.success) {
+          console.warn("[GoalRoadmap] Toggle failed:", json.error);
+        }
+        await fetchGoals();
+      } catch {
+        console.warn("[GoalRoadmap] Toggle request failed");
+        await fetchGoals();
+      }
+    },
+    [fetchGoals]
+  );
+
+  // Don't render anything while loading or if no goals generated
+  if (loading || generating) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center">
+          <Loader2 className="h-6 w-6 animate-spin text-[#ff6a1a] mx-auto mb-2" />
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {generating ? "Building your roadmap..." : "Loading goals..."}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (goals.length === 0) {
+    return null;
+  }
+
+  const completedCount = goals.filter((g) => g.completed).length;
+  const totalCount = goals.length;
+  const progressPercent = Math.round((completedCount / totalCount) * 100);
+  const stageLabel = goals[0]?.stage
+    ? goals[0].stage.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+    : "Your";
+
+  // Find first incomplete goal as "current step"
+  const currentGoalId = goals.find((g) => !g.completed)?.id;
+
+  return (
+    <Card className="overflow-hidden">
+      {/* Header */}
+      <div className="px-6 pt-6 pb-4">
+        <div className="flex items-center justify-between mb-3">
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 rounded-lg bg-[#ff6a1a]/10 flex items-center justify-center">
+              <Target className="h-4 w-4 text-[#ff6a1a]" />
+            </div>
+            <div>
+              <h3 className="text-base font-bold text-gray-900 dark:text-white">
+                Your Roadmap
+              </h3>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {stageLabel} stage goals
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-[#ff6a1a]" />
+            <span className="text-sm font-semibold text-gray-900 dark:text-white">
+              {completedCount}/{totalCount}
+            </span>
+          </div>
+        </div>
+
+        {/* Progress bar */}
+        <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-[#ff6a1a] to-orange-400 transition-all duration-500 ease-out"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Goals list */}
+      <CardContent className="pt-0 pb-6">
+        <div className="divide-y divide-gray-100 dark:divide-gray-800">
+          {goals.map((goal, index) => (
+            <GoalCard
+              key={goal.id}
+              goal={goal}
+              stepNumber={index + 1}
+              isCurrentStep={goal.id === currentGoalId}
+              onToggle={handleToggle}
+            />
+          ))}
+        </div>
+
+        {/* Completion message */}
+        {completedCount === totalCount && (
+          <div className="mt-4 p-4 rounded-xl bg-green-50 dark:bg-green-900/20 text-center">
+            <p className="text-sm font-semibold text-green-700 dark:text-green-400">
+              All goals complete! Chat with FRED to unlock your next milestones.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/mobile/mobile-home.tsx
+++ b/components/mobile/mobile-home.tsx
@@ -17,6 +17,7 @@ import {
   Send,
 } from "lucide-react";
 import { GetStartedWithFred } from "@/components/dashboard/get-started-with-fred";
+import { GoalRoadmap } from "@/components/dashboard/goal-roadmap";
 import { cn } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
 import { useTier } from "@/lib/context/tier-context";
@@ -154,6 +155,7 @@ export function MobileHome() {
         </div>
         <MobileChatInput />
         <GetStartedWithFred variant="mobile" />
+        <GoalRoadmap />
       </div>
     );
   }
@@ -175,6 +177,9 @@ export function MobileHome() {
 
       {/* Get Started with Fred */}
       <GetStartedWithFred variant="mobile" />
+
+      {/* Goal Roadmap — structured milestones by funding stage */}
+      <GoalRoadmap />
 
       {/* Today's Focus -- most important decision */}
       <TodaysFocus

--- a/lib/fred/context-builder.ts
+++ b/lib/fred/context-builder.ts
@@ -415,6 +415,7 @@ function buildContextBlock(data: FounderContextData): string {
     lines.push("- Go deeper: ask about the specifics that onboarding didn't capture (product status, traction metrics, runway, 90-day goal, who their buyer is).");
     lines.push("- Apply the Universal Entry Flow with context: since you know their challenge, start there. Ask what they've tried, what's working, what's stuck.");
     lines.push("- Begin building the full Founder Snapshot by filling in the missing fields through natural conversation.");
+    lines.push("- A personalized goal roadmap has been generated on their dashboard based on their funding stage. Reference it naturally: \"I've mapped out a roadmap for your stage — you can track progress on your dashboard.\"");
   } else if (isFirstConversation && !hasProfileData) {
     // Skipped onboarding or no data -> FRED should run the Founder Intake Protocol
     lines.push("## HANDOFF: FIRST CONVERSATION (NO ONBOARDING DATA)");
@@ -426,6 +427,7 @@ function buildContextBlock(data: FounderContextData): string {
     lines.push("- Do NOT mention onboarding, forms, or that data is missing. Just mentor naturally.");
     lines.push("- If they jump straight to a specific topic, collect the 2-3 most critical fundamentals for that topic, then help them. Do not block them from getting value.");
     lines.push("- Ask 2-3 questions at a time, respond thoughtfully, then gather more. This is mentoring, not an interrogation.");
+    lines.push("- Once you learn their funding stage, a personalized goal roadmap will be generated on their dashboard. Mention it naturally once you know their stage.");
   } else {
     // Returning user with context
     lines.push("Use this snapshot to personalize your mentoring. Skip intake questions you already have answers to. Reference what you know naturally.");

--- a/lib/goals/goal-service.ts
+++ b/lib/goals/goal-service.ts
@@ -1,0 +1,170 @@
+/**
+ * Goal Service — Data layer for structured goal sets
+ *
+ * Manages founder goal roadmaps stored in the founder_goals table.
+ * Goals are generated based on the founder's funding stage and
+ * displayed on the dashboard as a personalized roadmap.
+ *
+ * Linear: AI-1283
+ */
+
+import { createServiceClient } from "@/lib/supabase/server";
+import { getGoalSetForStage, type FundingStage } from "./goal-sets";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface FounderGoal {
+  id: string;
+  userId: string;
+  stage: string;
+  title: string;
+  description: string;
+  category: string;
+  sortOrder: number;
+  completed: boolean;
+  completedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================================
+// Query Functions
+// ============================================================================
+
+/**
+ * Get all goals for a user, ordered by sort_order.
+ */
+export async function getFounderGoals(userId: string): Promise<FounderGoal[]> {
+  const supabase = createServiceClient();
+
+  const { data, error } = await supabase
+    .from("founder_goals")
+    .select("*")
+    .eq("user_id", userId)
+    .order("sort_order", { ascending: true });
+
+  if (error) {
+    console.error("[Goals] Failed to fetch:", error);
+    return [];
+  }
+
+  return (data || []).map(mapRow);
+}
+
+/**
+ * Generate and store goal set for a user based on their funding stage.
+ * If goals already exist for the user, returns existing goals (no overwrite).
+ * Pass `force: true` to regenerate (deletes existing goals first).
+ */
+export async function generateGoalSet(
+  userId: string,
+  stage: string | null,
+  options?: { force?: boolean }
+): Promise<FounderGoal[]> {
+  const supabase = createServiceClient();
+
+  // Check for existing goals
+  const { data: existing, error: checkError } = await supabase
+    .from("founder_goals")
+    .select("id")
+    .eq("user_id", userId)
+    .limit(1);
+
+  if (checkError) {
+    console.error("[Goals] Failed to check existing:", checkError);
+    return [];
+  }
+
+  if (existing && existing.length > 0 && !options?.force) {
+    return getFounderGoals(userId);
+  }
+
+  // If forcing, delete existing goals first
+  if (options?.force && existing && existing.length > 0) {
+    const { error: deleteError } = await supabase
+      .from("founder_goals")
+      .delete()
+      .eq("user_id", userId);
+
+    if (deleteError) {
+      console.error("[Goals] Failed to delete existing:", deleteError);
+      return [];
+    }
+  }
+
+  // Generate goals from the stage definition
+  const goalSet = getGoalSetForStage(stage);
+  const inserts = goalSet.goals.map((goal) => ({
+    user_id: userId,
+    stage: goalSet.stage,
+    title: goal.title,
+    description: goal.description,
+    category: goal.category,
+    sort_order: goal.order,
+    completed: false,
+  }));
+
+  const { data, error } = await supabase
+    .from("founder_goals")
+    .insert(inserts)
+    .select("*");
+
+  if (error) {
+    console.error("[Goals] Failed to store:", error);
+    return [];
+  }
+
+  return (data || []).map(mapRow);
+}
+
+/**
+ * Toggle a goal's completion status.
+ */
+export async function toggleGoalComplete(
+  userId: string,
+  goalId: string,
+  completed: boolean
+): Promise<FounderGoal | null> {
+  const supabase = createServiceClient();
+
+  const { data, error } = await supabase
+    .from("founder_goals")
+    .update({
+      completed,
+      completed_at: completed ? new Date().toISOString() : null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", goalId)
+    .eq("user_id", userId)
+    .select("*")
+    .single();
+
+  if (error) {
+    console.error("[Goals] Failed to toggle:", error);
+    return null;
+  }
+
+  return mapRow(data);
+}
+
+// ============================================================================
+// Row Mapper
+// ============================================================================
+
+function mapRow(row: Record<string, unknown>): FounderGoal {
+  return {
+    id: row.id as string,
+    userId: row.user_id as string,
+    stage: row.stage as string,
+    title: row.title as string,
+    description: row.description as string,
+    category: row.category as string,
+    sortOrder: row.sort_order as number,
+    completed: (row.completed as boolean) || false,
+    completedAt: (row.completed_at as string) || null,
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  };
+}

--- a/lib/goals/goal-sets.ts
+++ b/lib/goals/goal-sets.ts
@@ -1,0 +1,203 @@
+/**
+ * Goal Sets by Funding Stage
+ *
+ * Structured goal roadmaps personalized to each founder's stage.
+ * Generated after onboarding conversation with FRED, displayed on dashboard.
+ *
+ * Linear: AI-1283
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type FundingStage = "idea" | "pre-seed" | "seed" | "series-a";
+
+export interface GoalDefinition {
+  /** Short title displayed in the roadmap */
+  title: string;
+  /** Detailed description of what this goal means */
+  description: string;
+  /** Ordered position within the stage (1-based) */
+  order: number;
+  /** Category tag for grouping/filtering */
+  category: "validation" | "product" | "growth" | "fundraising" | "strategy";
+}
+
+export interface GoalSetDefinition {
+  stage: FundingStage;
+  label: string;
+  goals: GoalDefinition[];
+}
+
+// ============================================================================
+// Goal Set Definitions
+// ============================================================================
+
+const IDEA_STAGE_GOALS: GoalDefinition[] = [
+  {
+    title: "Validate your idea",
+    description:
+      "Talk to at least 10 potential customers. Identify the core problem you solve and confirm people actually experience it. Document their exact words.",
+    order: 1,
+    category: "validation",
+  },
+  {
+    title: "Build your MVP",
+    description:
+      "Create the simplest version of your product that solves the core problem. Focus on one use case, not a feature list. Ship something people can use.",
+    order: 2,
+    category: "product",
+  },
+  {
+    title: "Get your first customers",
+    description:
+      "Acquire your first 5-10 paying customers (or committed users for free products). Prove that someone other than friends and family will use what you built.",
+    order: 3,
+    category: "growth",
+  },
+  {
+    title: "Become fundable",
+    description:
+      "Build a compelling narrative: problem, solution, traction, team. Have a pitch deck ready, understand your unit economics, and know your ask.",
+    order: 4,
+    category: "fundraising",
+  },
+];
+
+const PRE_SEED_GOALS: GoalDefinition[] = [
+  {
+    title: "Analyze where you really are",
+    description:
+      "Honest assessment of product-market fit signals, burn rate, team gaps, and competitive position. Use FRED's Reality Lens to get an unvarnished view.",
+    order: 1,
+    category: "strategy",
+  },
+  {
+    title: "Identify what needs to change to be fundable",
+    description:
+      "Compare your metrics to stage benchmarks. Identify the 2-3 things investors will ask about that you can't answer yet. Build a plan to close those gaps.",
+    order: 2,
+    category: "fundraising",
+  },
+  {
+    title: "Analyze your existing pitch deck",
+    description:
+      "Upload your deck to FRED for a thorough review. Get specific feedback on narrative flow, data presentation, and investor objection points.",
+    order: 3,
+    category: "fundraising",
+  },
+  {
+    title: "Create a new pitch deck",
+    description:
+      "Build a pitch deck that tells your story with data. Include problem, solution, market size, business model, traction, team, and ask. FRED can help structure it.",
+    order: 4,
+    category: "fundraising",
+  },
+  {
+    title: "Get introduced to investors via Boardy",
+    description:
+      "Use the Boardy network to get warm introductions to investors who match your stage, sector, and geography. Quality over quantity.",
+    order: 5,
+    category: "fundraising",
+  },
+];
+
+const SEED_GOALS: GoalDefinition[] = [
+  {
+    title: "Validate unit economics",
+    description:
+      "Know your CAC, LTV, payback period, and gross margins. Prove that each customer is worth more than what it costs to acquire them.",
+    order: 1,
+    category: "strategy",
+  },
+  {
+    title: "Complete market sizing and competitive analysis",
+    description:
+      "Build a defensible TAM/SAM/SOM analysis. Map your competitive landscape and articulate your unfair advantage clearly.",
+    order: 2,
+    category: "strategy",
+  },
+  {
+    title: "Achieve investor readiness",
+    description:
+      "Score 80+ on the Investor Readiness Score. Have clean financials, a data room ready, and answers to the top 20 investor questions.",
+    order: 3,
+    category: "fundraising",
+  },
+  {
+    title: "Refine your pitch",
+    description:
+      "Iterate on your pitch until it's crisp. Practice with FRED's pitch review, get timing right, and nail the Q&A. Every slide should earn its place.",
+    order: 4,
+    category: "fundraising",
+  },
+];
+
+const SERIES_A_GOALS: GoalDefinition[] = [
+  {
+    title: "Demonstrate repeatable growth",
+    description:
+      "Show consistent month-over-month growth in key metrics. Prove that your growth engine works and can scale with more capital.",
+    order: 1,
+    category: "growth",
+  },
+  {
+    title: "Optimize unit economics for scale",
+    description:
+      "Drive down CAC and increase LTV. Show a clear path to profitability at scale with improving margins as you grow.",
+    order: 2,
+    category: "strategy",
+  },
+  {
+    title: "Build the Series A narrative",
+    description:
+      "Articulate why now is the right time to pour fuel on the fire. Show product-market fit, team readiness, and a clear use of funds.",
+    order: 3,
+    category: "fundraising",
+  },
+  {
+    title: "Strengthen your leadership team",
+    description:
+      "Identify and plan for key hires. Investors want to see that you can build the team needed to execute at the next level.",
+    order: 4,
+    category: "strategy",
+  },
+];
+
+// ============================================================================
+// Registry
+// ============================================================================
+
+export const GOAL_SETS: Record<FundingStage, GoalSetDefinition> = {
+  idea: {
+    stage: "idea",
+    label: "Idea Stage",
+    goals: IDEA_STAGE_GOALS,
+  },
+  "pre-seed": {
+    stage: "pre-seed",
+    label: "Friends & Family / Pre-Seed",
+    goals: PRE_SEED_GOALS,
+  },
+  seed: {
+    stage: "seed",
+    label: "Seed",
+    goals: SEED_GOALS,
+  },
+  "series-a": {
+    stage: "series-a",
+    label: "Series A+",
+    goals: SERIES_A_GOALS,
+  },
+};
+
+/**
+ * Get the goal set definition for a given funding stage.
+ * Falls back to idea stage if stage is unknown.
+ */
+export function getGoalSetForStage(stage: string | null): GoalSetDefinition {
+  if (!stage) return GOAL_SETS["idea"];
+  const normalized = stage.toLowerCase().trim() as FundingStage;
+  return GOAL_SETS[normalized] ?? GOAL_SETS["idea"];
+}

--- a/supabase/migrations/20260303000001_founder_goals.sql
+++ b/supabase/migrations/20260303000001_founder_goals.sql
@@ -1,0 +1,40 @@
+-- Structured goal sets by funding stage
+-- Stores personalized goal roadmaps generated after onboarding.
+-- Linear: AI-1283
+
+CREATE TABLE IF NOT EXISTS founder_goals (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  stage TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'strategy' CHECK (category IN ('validation', 'product', 'growth', 'fundraising', 'strategy')),
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  completed BOOLEAN NOT NULL DEFAULT FALSE,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_founder_goals_user_id ON founder_goals(user_id);
+CREATE INDEX IF NOT EXISTS idx_founder_goals_user_active ON founder_goals(user_id, completed);
+
+-- RLS
+ALTER TABLE founder_goals ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own goals"
+  ON founder_goals FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own goals"
+  ON founder_goals FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own goals"
+  ON founder_goals FOR UPDATE
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Service role full access on founder_goals"
+  ON founder_goals FOR ALL
+  USING (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary

- Adds personalized goal roadmaps on the dashboard based on the founder's funding stage (idea, pre-seed, seed, series-a)
- Goal sets auto-generate when the dashboard loads, pulling the stage from the user's profile
- Goals are stored in a new `founder_goals` table with RLS policies
- FRED's context builder references the roadmap so the AI can guide founders through their goals naturally

## Changes

### New files
- `lib/goals/goal-sets.ts` — Goal definitions for each funding stage
- `lib/goals/goal-service.ts` — DB service (CRUD, generation, toggle)
- `app/api/dashboard/goals/route.ts` — REST API (GET/POST/PATCH)
- `components/dashboard/goal-roadmap.tsx` — Dashboard roadmap component
- `supabase/migrations/20260303000001_founder_goals.sql` — DB migration

### Modified files
- `app/dashboard/page.tsx` — Added GoalRoadmap to desktop dashboard
- `components/mobile/mobile-home.tsx` — Added GoalRoadmap to mobile dashboard
- `lib/fred/context-builder.ts` — FRED now references goal roadmap in handoff instructions

## Test plan
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Run migration against staging DB
- [ ] Test goal generation via `POST /api/dashboard/goals` with different stage values
- [ ] Verify dashboard renders the GoalRoadmap component
- [ ] Toggle goal completion and verify persistence
- [ ] Test with no profile stage (should default to idea stage goals)

Linear: AI-1283

Generated with [Claude Code](https://claude.com/claude-code)