### PR TITLE
AI-1893: Fix Fred AI interface — reduce user friction and stuck states

### DIFF
--- a/app/dashboard/startup-process/page.tsx
+++ b/app/dashboard/startup-process/page.tsx
@@ -93,21 +93,21 @@ async function validateStep(
       result.synthesis?.confidence ?? result.response?.confidence ?? 0.5;
 
     // Determine pass/fail from confidence + content signals
+    // Thresholds relaxed to reduce user friction (AI-1893)
     const lc = content.toLowerCase();
     let status: ValidationResult["status"];
     if (
-      confidence >= 0.75 ||
+      confidence >= 0.6 ||
       lc.includes("pass") ||
-      (lc.includes("strong") && !lc.includes("not strong"))
+      (lc.includes("strong") && !lc.includes("not strong")) ||
+      (lc.includes("good") && !lc.includes("not good"))
     ) {
       status = "pass";
     } else if (
-      confidence < 0.4 ||
-      lc.includes("blocked") ||
-      lc.includes("critical gap") ||
-      lc.includes("missing")
+      confidence < 0.25 ||
+      (lc.includes("blocked") && lc.includes("critical gap"))
     ) {
-      status = "blocked";
+      status = "needs_work"; // Never hard-block — always let users improve and retry
     } else {
       status = "needs_work";
     }
@@ -257,9 +257,7 @@ export default function StartupProcessPage() {
               status:
                 result.status === "pass"
                   ? "validated"
-                  : result.status === "blocked"
-                  ? "blocked"
-                  : "in_progress",
+                  : "in_progress", // Never hard-block users (AI-1893)
               completedAt:
                 result.status === "pass" ? new Date().toISOString() : undefined,
             } as ProcessStep;
@@ -290,11 +288,9 @@ export default function StartupProcessPage() {
       setHasUnsavedChanges(true);
 
       if (result.status === "pass") {
-        toast.success("Step validated successfully");
-      } else if (result.status === "blocked") {
-        toast.error(result.feedback || "Validation blocked");
+        toast.success("Step validated — great work!");
       } else {
-        toast.info(result.feedback || "Step needs improvement");
+        toast.info("Fred has some suggestions to strengthen this step. You can update your answers or proceed anyway.");
       }
 
       return result;

--- a/components/startup-process/startup-process-wizard.tsx
+++ b/components/startup-process/startup-process-wizard.tsx
@@ -18,6 +18,7 @@ import {
   LayoutGrid,
   ListOrdered,
   AlertTriangle,
+  SkipForward,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { StepForm } from "./step-form";
@@ -52,7 +53,8 @@ export function StartupProcessWizard({
     (stepNumber: StepNumber): boolean => {
       const step = process.steps.find((s) => s.stepNumber === stepNumber);
       if (!step) return false;
-      return step.status === "validated";
+      // Allow advancing if validated, skipped, or has data entered (AI-1893)
+      return step.status === "validated" || step.status === "skipped" || step.status === "in_progress";
     },
     [process.steps]
   );
@@ -61,10 +63,10 @@ export function StartupProcessWizard({
     (stepNumber: StepNumber): boolean => {
       // First step is always accessible
       if (stepNumber === 1) return true;
-      // Step is accessible if all previous steps are validated
+      // Step is accessible if all previous steps have been touched (validated, skipped, or in_progress)
       for (let i = 1; i < stepNumber; i++) {
         const prevStep = process.steps.find((s) => s.stepNumber === i);
-        if (!prevStep || prevStep.status !== "validated") {
+        if (!prevStep || prevStep.status === "not_started") {
           return false;
         }
       }
@@ -113,6 +115,25 @@ export function StartupProcessWizard({
 
   const handleDataChange = (data: StepData) => {
     onDataChange(process.currentStep, data);
+  };
+
+  // Skip this step and move forward (AI-1893: reduce friction)
+  const handleSkip = () => {
+    if (process.currentStep < 9) {
+      // Mark step as in_progress so it's "touched" for accessibility
+      // The step will show as incomplete but won't block navigation
+      if (currentStep?.status === "not_started") {
+        onDataChange(process.currentStep, {} as StepData);
+      }
+      onStepChange((process.currentStep + 1) as StepNumber);
+    }
+  };
+
+  // Proceed even when validation says needs_work (AI-1893)
+  const handleProceedAnyway = () => {
+    if (process.currentStep < 9) {
+      onStepChange((process.currentStep + 1) as StepNumber);
+    }
   };
 
   // Check if current step has required fields filled
@@ -221,6 +242,8 @@ export function StartupProcessWizard({
                                 ? "bg-green-500 text-white"
                                 : step.status === "blocked"
                                 ? "bg-amber-500 text-white"
+                                : step.status === "skipped"
+                                ? "bg-gray-400 dark:bg-gray-500 text-white"
                                 : isCurrent
                                 ? "bg-[#ff6a1a] text-white ring-4 ring-[#ff6a1a]/20"
                                 : "bg-gray-200 dark:bg-gray-700 text-gray-600 dark:text-gray-300"
@@ -228,6 +251,8 @@ export function StartupProcessWizard({
                           >
                             {step.status === "validated" ? (
                               <CheckCircle className="h-5 w-5" />
+                            ) : step.status === "skipped" ? (
+                              <SkipForward className="h-4 w-4" />
                             ) : !isAccessible ? (
                               <Lock className="h-4 w-4" />
                             ) : (
@@ -336,7 +361,7 @@ export function StartupProcessWizard({
                         {currentStep?.status === "blocked" && (
                           <Badge className="bg-amber-500 text-white shrink-0">
                             <AlertTriangle className="mr-1 h-3 w-3" />
-                            Needs Work
+                            Suggestions Available
                           </Badge>
                         )}
                       </div>
@@ -379,6 +404,19 @@ export function StartupProcessWizard({
                         </div>
 
                         <div className="flex items-center gap-2">
+                          {/* Skip for now — always available unless validated or last step */}
+                          {currentStep?.status !== "validated" &&
+                            process.currentStep < 9 && (
+                              <Button
+                                variant="ghost"
+                                onClick={handleSkip}
+                                className="text-muted-foreground hover:text-foreground gap-1"
+                              >
+                                <SkipForward className="h-4 w-4" />
+                                Skip for now
+                              </Button>
+                            )}
+
                           {currentStep?.status !== "validated" && (
                             <Button
                               onClick={handleValidate}
@@ -393,6 +431,22 @@ export function StartupProcessWizard({
                               Validate Step
                             </Button>
                           )}
+
+                          {/* Proceed anyway after needs_work validation */}
+                          {currentStep?.validation &&
+                            currentStep.validation.status !== "pass" &&
+                            currentStep.status !== "validated" &&
+                            process.currentStep < 9 && (
+                              <Button
+                                variant="outline"
+                                onClick={handleProceedAnyway}
+                                className="gap-1 border-amber-300 text-amber-700 hover:bg-amber-50 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-950"
+                              >
+                                Proceed Anyway
+                                <ChevronRight className="h-4 w-4" />
+                              </Button>
+                            )}
+
                           {currentStep?.status === "validated" &&
                             process.currentStep < 9 && (
                               <Button

--- a/components/startup-process/step-form.tsx
+++ b/components/startup-process/step-form.tsx
@@ -50,7 +50,7 @@ function Step1Form({
         </Label>
         <Textarea
           id="problemStatement"
-          placeholder="Describe the specific problem you're solving in 2-3 sentences..."
+          placeholder="e.g., 'First-time founders waste 3-6 months building products nobody wants because they skip customer validation. They don't know who to talk to or what questions to ask.'"
           value={formData.problemStatement}
           onChange={(e) => handleChange("problemStatement", e.target.value)}
           disabled={disabled}
@@ -58,7 +58,7 @@ function Step1Form({
           className="resize-none"
         />
         <p className="text-xs text-muted-foreground">
-          Be specific. Avoid vague statements like &quot;improve productivity.&quot;
+          Describe the problem in your own words — a sentence or two is fine. You can always come back and refine it.
         </p>
       </div>
 
@@ -68,38 +68,47 @@ function Step1Form({
         </Label>
         <Input
           id="who"
-          placeholder="e.g., Early-stage founders with technical backgrounds"
+          placeholder="e.g., First-time founders, solo developers, small agency owners"
           value={formData.who}
           onChange={(e) => handleChange("who", e.target.value)}
           disabled={disabled}
         />
+        <p className="text-xs text-muted-foreground">
+          Who are the people feeling this pain? Even a rough description is a great start.
+        </p>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="space-y-2">
           <Label htmlFor="frequency">
-            How often do they encounter this? <span className="text-destructive">*</span>
+            How often? <span className="text-destructive">*</span>
           </Label>
           <Input
             id="frequency"
-            placeholder="e.g., Daily, Weekly, Monthly"
+            placeholder="e.g., Every day, A few times a week, Constantly"
             value={formData.frequency}
             onChange={(e) => handleChange("frequency", e.target.value)}
             disabled={disabled}
           />
+          <p className="text-xs text-muted-foreground">
+            Use whatever language feels natural.
+          </p>
         </div>
 
         <div className="space-y-2">
           <Label htmlFor="urgency">
-            How urgent is the need? <span className="text-destructive">*</span>
+            How urgent? <span className="text-destructive">*</span>
           </Label>
           <Input
             id="urgency"
-            placeholder="e.g., Critical, High, Medium"
+            placeholder="e.g., Very urgent, Nice to solve, Hair on fire"
             value={formData.urgency}
             onChange={(e) => handleChange("urgency", e.target.value)}
             disabled={disabled}
           />
+          <p className="text-xs text-muted-foreground">
+            In your own words — there&apos;s no wrong answer.
+          </p>
         </div>
       </div>
     </div>
@@ -608,7 +617,7 @@ function Step8Form({
           rows={4}
         />
         <p className="text-xs text-muted-foreground">
-          Be specific and quantitative. Avoid vague goals.
+          What would success look like? Numbers help but aren&apos;t required — describe it however makes sense to you.
         </p>
       </div>
 

--- a/components/startup-process/validation-feedback.tsx
+++ b/components/startup-process/validation-feedback.tsx
@@ -25,20 +25,20 @@ const statusConfig = {
     description: "This step has been validated and you can proceed.",
   },
   needs_work: {
+    icon: Lightbulb,
+    color: "text-amber-500",
+    bgColor: "bg-amber-50 dark:bg-amber-950",
+    borderColor: "border-amber-200 dark:border-amber-800",
+    title: "Suggestions Available",
+    description: "Fred has some ideas to strengthen your answers. You can update them or proceed whenever you're ready.",
+  },
+  blocked: {
     icon: AlertTriangle,
     color: "text-amber-500",
     bgColor: "bg-amber-50 dark:bg-amber-950",
     borderColor: "border-amber-200 dark:border-amber-800",
-    title: "Needs Work",
-    description: "Review the feedback below and make improvements.",
-  },
-  blocked: {
-    icon: XCircle,
-    color: "text-red-500",
-    bgColor: "bg-red-50 dark:bg-red-950",
-    borderColor: "border-red-200 dark:border-red-800",
-    title: "Blocked",
-    description: "Critical issues must be resolved before proceeding.",
+    title: "Needs More Detail",
+    description: "A few areas could use more thought. Review the suggestions below — you can still proceed if you prefer.",
   },
 };
 
@@ -104,18 +104,18 @@ export function ValidationFeedback({ validation, stepNumber }: ValidationFeedbac
           </p>
         </div>
 
-        {/* Blocker Reasons */}
+        {/* Areas to strengthen */}
         {validation.blockerReasons && validation.blockerReasons.length > 0 && (
           <div className="space-y-2">
-            <h4 className="text-sm font-medium flex items-center gap-2 text-red-600">
-              <XCircle className="h-4 w-4" />
-              Blockers to Resolve
+            <h4 className="text-sm font-medium flex items-center gap-2 text-amber-600">
+              <AlertTriangle className="h-4 w-4" />
+              Areas to Strengthen
             </h4>
             <ul className="space-y-2">
               {validation.blockerReasons.map((reason, index) => (
                 <li
                   key={index}
-                  className="flex items-start gap-2 text-sm p-2 rounded-lg bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300"
+                  className="flex items-start gap-2 text-sm p-2 rounded-lg bg-amber-50 dark:bg-amber-950 text-amber-700 dark:text-amber-300"
                 >
                   <span className="font-medium shrink-0">{index + 1}.</span>
                   <span>{reason}</span>


### PR DESCRIPTION
## Summary
- Lowered validation confidence thresholds so more user answers pass on first attempt
- Removed hard-blocking states — users are never stuck; "blocked" becomes soft suggestions
- Added "Skip for now" and "Proceed Anyway" buttons so users can always move forward
- Relaxed step navigation to allow advancing when steps are touched (not just validated)
- Softened all feedback language: "Blockers" → "Suggestions Available", "Needs Work" → encouraging tone
- Replaced vague placeholder text with concrete examples to reduce blank-field paralysis

## Test plan
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Production build passes (`npm run build`)
- [ ] Manual test: fill out step 1 partially, verify "Skip for now" button appears
- [ ] Manual test: validate with weak answers, verify "Proceed Anyway" button appears
- [ ] Manual test: verify no step ever shows "Blocked" status or red error styling

Linear: AI-1893

🤖 Generated with [Claude Code](https://claude.com/claude-code)