### PR TITLE
AI-1885: Fix journey analyzer scores not saving properly

### DIFF
--- a/app/api/fred/reality-lens/route.ts
+++ b/app/api/fred/reality-lens/route.ts
@@ -25,7 +25,7 @@ import {
   validateInput,
   type RealityLensInput,
 } from "@/lib/fred/reality-lens";
-import { logJourneyEventAsync } from "@/lib/db/journey-events";
+import { logJourneyEvent } from "@/lib/db/journey-events";
 
 // ============================================================================
 // Rate Limit Configuration
@@ -124,27 +124,6 @@ export async function POST(req: NextRequest) {
     // Perform assessment
     const result = await assessIdea(input);
 
-    // Persist journey event BEFORE returning response (critical for dashboard)
-    try {
-      const { sql } = await import("@/lib/db/supabase-sql");
-
-      await sql`
-        INSERT INTO journey_events (user_id, event_type, event_data, score_after)
-        VALUES (
-          ${userId},
-          'analysis_completed',
-          ${JSON.stringify({
-            assessmentId: result.metadata.assessmentId,
-            verdict: result.verdict,
-            idea: input.idea.slice(0, 200),
-          })},
-          ${result.overallScore}
-        )
-      `;
-    } catch (journeyErr) {
-      console.error("[Reality Lens API] Journey event save failed:", journeyErr);
-    }
-
     // Save detailed analysis to reality_lens_analyses (non-blocking, not dashboard-critical)
     (async () => {
       try {
@@ -183,8 +162,8 @@ export async function POST(req: NextRequest) {
     })();
 
     // Log journey event so the Journey dashboard Idea Score updates
-    // Uses resilient logJourneyEventAsync with retry logic
-    logJourneyEventAsync({
+    // Await to ensure score is persisted before returning response (critical for dashboard)
+    await logJourneyEvent({
       userId,
       eventType: "analysis_completed",
       eventData: {

--- a/app/api/investor-lens/route.ts
+++ b/app/api/investor-lens/route.ts
@@ -7,6 +7,7 @@ import { extractAndSaveInsights } from "@/lib/ai/insight-extractor";
 import { checkTierForRequest } from "@/lib/api/tier-middleware";
 import { UserTier } from "@/lib/constants";
 import { logger } from "@/lib/logger";
+import { logJourneyEventAsync } from "@/lib/db/journey-events";
 
 // Type definitions
 
@@ -734,26 +735,37 @@ export async function POST(request: NextRequest) {
       // Don't fail the main request if insight extraction fails
     }
 
-    // Log journey event
-    try {
-      await sql`
-        INSERT INTO journey_events (user_id, event_type, event_data)
-        VALUES (
-          ${userId},
-          'investor_lens_evaluation',
-          ${JSON.stringify({
-            evaluationId: savedEvaluation.id,
-            fundingStage,
-            icVerdict: evaluation.icVerdict,
-            ventureBackable: evaluation.ventureBackable,
-            requestId: trackedResult.requestId,
-            variant: trackedResult.variant,
-          })}
-        )
-      `;
-    } catch (err) {
-      console.error("[Investor Lens] Journey event logging failed:", err);
-    }
+    // Calculate overall score from axes for journey event persistence
+    const axisScores = [
+      evaluation.axes.team.score,
+      evaluation.axes.market.score,
+      evaluation.axes.problem.score,
+      evaluation.axes.solution.score,
+      evaluation.axes.gtm.score,
+      evaluation.axes.traction.score,
+      evaluation.axes.businessModel.score,
+      evaluation.axes.fundFit.score,
+      evaluation.axes.valuation.score,
+    ];
+    const overallScore = Math.round(
+      axisScores.reduce((sum, s) => sum + s, 0) / axisScores.length
+    );
+
+    // Log journey event with score_after for dashboard retrieval
+    // Uses resilient logJourneyEventAsync with retry logic (service-role client)
+    logJourneyEventAsync({
+      userId,
+      eventType: "investor_lens_evaluation",
+      eventData: {
+        evaluationId: savedEvaluation.id,
+        fundingStage,
+        icVerdict: evaluation.icVerdict,
+        ventureBackable: evaluation.ventureBackable,
+        requestId: trackedResult.requestId,
+        variant: trackedResult.variant,
+      },
+      scoreAfter: overallScore,
+    });
 
     return NextResponse.json(
       {


### PR DESCRIPTION
## Summary
- **Reality Lens**: Removed duplicate raw SQL insert into journey_events, switched from fire-and-forget `logJourneyEventAsync` to awaited `logJourneyEvent` so dashboard scores persist before API response returns
- **Investor Lens**: Added `score_after` calculation (average of 9 axis scores) which was completely missing, switched from raw SQL to `logJourneyEventAsync` with retry logic using service-role client (bypasses RLS)

## Test plan
- [ ] Run Reality Lens assessment, verify `journey_events` row has `score_after` populated
- [ ] Run Investor Lens evaluation, verify `journey_events` row has `score_after` with averaged axis score
- [ ] Check `/api/journey/stats` returns updated `ideaScore` after Reality Lens run
- [ ] Verify no duplicate journey_events rows from Reality Lens

🤖 Generated with [Claude Code](https://claude.com/claude-code)