### PR TITLE
AI-2228: Complete funnel at u.joinsahara.com with sync integration

### DIFF
--- a/app/api/funnel/sync/route.ts
+++ b/app/api/funnel/sync/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/server";
+import { corsHeaders, handleCorsOptions } from "@/lib/api/cors";
+
+/**
+ * POST /api/funnel/sync
+ * Receives funnel data (chat messages + journey progress) from u.joinsahara.com.
+ *
+ * Stores data in funnel_sessions table keyed by sessionId.
+ * When a user signs up for the full platform, this data is used to pre-populate
+ * their account (chat history, journey progress).
+ *
+ * No authentication required — the funnel is a public static app.
+ */
+export async function POST(request: NextRequest) {
+  const origin = request.headers.get("origin");
+
+  try {
+    const body = await request.json();
+    const { sessionId, chatMessages, journeyProgress, funnelVersion } = body;
+
+    if (!sessionId) {
+      return NextResponse.json(
+        { error: "sessionId is required" },
+        { status: 400, headers: corsHeaders(origin) }
+      );
+    }
+
+    const supabase = createServiceClient();
+
+    // Upsert funnel session data
+    const { error } = await supabase.from("funnel_sessions").upsert(
+      {
+        session_id: sessionId,
+        chat_messages: chatMessages || [],
+        journey_progress: journeyProgress || {},
+        funnel_version: funnelVersion || "1.0",
+        last_synced_at: new Date().toISOString(),
+      },
+      { onConflict: "session_id" }
+    );
+
+    if (error) {
+      // Table might not exist yet — fail silently in production
+      console.warn("[Funnel Sync] DB error:", error.message);
+      return NextResponse.json(
+        { ok: true, synced: false },
+        { headers: corsHeaders(origin) }
+      );
+    }
+
+    return NextResponse.json(
+      { ok: true, synced: true },
+      { headers: corsHeaders(origin) }
+    );
+  } catch (error) {
+    console.error("[Funnel Sync] Error:", error);
+    return NextResponse.json(
+      { ok: true, synced: false },
+      { headers: corsHeaders(origin) }
+    );
+  }
+}
+
+/**
+ * OPTIONS /api/funnel/sync
+ * Handle CORS preflight for cross-origin requests from the funnel.
+ */
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsOptions(request);
+}

--- a/funnel/src/App.tsx
+++ b/funnel/src/App.tsx
@@ -6,6 +6,7 @@ import { LandingPage } from '@/pages/LandingPage'
 import { ChatPage } from '@/pages/ChatPage'
 import { JourneyPage } from '@/pages/JourneyPage'
 import { FaqPage } from '@/pages/FaqPage'
+import { startPeriodicSync, stopPeriodicSync } from '@/lib/sync-service'
 
 const TAB_STORAGE_KEY = 'sahara-funnel-tab'
 
@@ -21,6 +22,12 @@ export default function App() {
   useEffect(() => {
     sessionStorage.setItem(TAB_STORAGE_KEY, activeTab)
   }, [activeTab])
+
+  // Start syncing funnel data to the platform API
+  useEffect(() => {
+    startPeriodicSync()
+    return () => stopPeriodicSync()
+  }, [])
 
   const goToChat = useCallback(() => setActiveTab('chat'), [])
 

--- a/supabase/migrations/20260315000001_funnel_sessions.sql
+++ b/supabase/migrations/20260315000001_funnel_sessions.sql
@@ -1,0 +1,26 @@
+-- Funnel session data from u.joinsahara.com
+-- Stores chat messages and journey progress for migration to full platform
+-- Linear: AI-2228
+
+CREATE TABLE IF NOT EXISTS funnel_sessions (
+  id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+  session_id text UNIQUE NOT NULL,
+  chat_messages jsonb DEFAULT '[]'::jsonb,
+  journey_progress jsonb DEFAULT '{}'::jsonb,
+  funnel_version text DEFAULT '1.0',
+  last_synced_at timestamptz DEFAULT now(),
+  migrated_to_user_id uuid REFERENCES auth.users(id),
+  created_at timestamptz DEFAULT now()
+);
+
+-- Index for lookup during migration
+CREATE INDEX IF NOT EXISTS idx_funnel_sessions_session_id ON funnel_sessions(session_id);
+CREATE INDEX IF NOT EXISTS idx_funnel_sessions_migrated ON funnel_sessions(migrated_to_user_id) WHERE migrated_to_user_id IS NOT NULL;
+
+-- Allow service role full access (no RLS needed — only server-side writes)
+ALTER TABLE funnel_sessions ENABLE ROW LEVEL SECURITY;
+
+-- Service role bypasses RLS, but add a policy for read access during migration
+CREATE POLICY "Users can read their migrated funnel data"
+  ON funnel_sessions FOR SELECT
+  USING (migrated_to_user_id = auth.uid());


### PR DESCRIPTION
Closes AI-2228

## Summary
- Wire up the existing sync service (`startPeriodicSync`/`stopPeriodicSync`) in the funnel's `App.tsx` so chat messages and journey progress are synced to the platform API
- Add `/api/funnel/sync` POST endpoint on the main app to receive and store funnel data via Supabase
- Add `funnel_sessions` DB migration with session_id, chat_messages (jsonb), journey_progress (jsonb), and a `migrated_to_user_id` column for linking to full platform accounts

The funnel app itself (React/Vite, mobile-first, 4-tab layout with Landing, Chat with Fred, Founder Journey, and FAQ) was already built in previous commits. This PR completes the data pipeline so funnel data persists server-side and is migratable when users sign up.

## What was already built (on main)
- `funnel/` — Vite + React + Tailwind CSS 4 app with mobile-first design
- Landing page with hero, features, testimonials, pricing (free + Pro)
- Chat with Fred (AI coaching with demo mode + API integration)
- Founder Journey (5-stage timeline with milestone tracking)
- FAQ section (8 questions with accordion UI)
- Stripe checkout integration via main app's `/api/funnel/checkout`
- PWA manifest, OG tags, Inter font

## Testing
- `cd funnel && npm run build` — passes (TypeScript + Vite)
- `npx tsc --noEmit` in root — passes (main app still compiles)
- Sync service gracefully degrades if API is unavailable

Linear: https://linear.app/ai-acrobatics/issue/AI-2228/frontend-build-funnel-version-at-ujoinsaharacom-react-mobile-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)