### PR TITLE
AI-2264: Wire up funnel data sync for platform migration

### DIFF
--- a/funnel/src/App.tsx
+++ b/funnel/src/App.tsx
@@ -6,6 +6,7 @@ import { LandingPage } from '@/pages/LandingPage'
 import { ChatPage } from '@/pages/ChatPage'
 import { JourneyPage } from '@/pages/JourneyPage'
 import { FaqPage } from '@/pages/FaqPage'
+import { startPeriodicSync, stopPeriodicSync } from '@/lib/sync-service'
 
 const TAB_STORAGE_KEY = 'sahara-funnel-tab'
 
@@ -21,6 +22,12 @@ export default function App() {
   useEffect(() => {
     sessionStorage.setItem(TAB_STORAGE_KEY, activeTab)
   }, [activeTab])
+
+  // Start syncing funnel data to the platform API
+  useEffect(() => {
+    startPeriodicSync()
+    return () => stopPeriodicSync()
+  }, [])
 
   const goToChat = useCallback(() => setActiveTab('chat'), [])
 

--- a/funnel/src/pages/ChatPage.tsx
+++ b/funnel/src/pages/ChatPage.tsx
@@ -9,6 +9,7 @@ import {
   loadChatHistory,
   saveChatHistory,
 } from '@/lib/chat-service'
+import { scheduleFunnelSync } from '@/lib/sync-service'
 
 const SUGGESTION_CHIPS = [
   "I have a startup idea",
@@ -40,10 +41,11 @@ export function ChatPage() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages, isLoading])
 
-  // Save to localStorage whenever messages change
+  // Save to localStorage whenever messages change, then schedule a sync
   useEffect(() => {
     if (messages.length > 1) {
       saveChatHistory(messages)
+      scheduleFunnelSync()
     }
   }, [messages])
 

--- a/funnel/src/pages/JourneyPage.tsx
+++ b/funnel/src/pages/JourneyPage.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { Check, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { JOURNEY_STAGES, BRAND } from '@/lib/constants'
+import { scheduleFunnelSync } from '@/lib/sync-service'
 
 const STORAGE_KEY = 'sahara-funnel-journey'
 
@@ -27,6 +28,7 @@ export function JourneyPage() {
     const newProgress = { ...progress, [key]: !progress[key] }
     setProgress(newProgress)
     saveProgress(newProgress)
+    scheduleFunnelSync()
   }
 
   const getStageProgress = (stageId: string, total: number) => {


### PR DESCRIPTION
## Summary

The funnel frontend at u.joinsahara.com was already built (AI-1943) with all core features:
- **Chat/Talk with Fred** — AI chat with demo mode and API fallback
- **Founder Journey** — Interactive milestone tracker across 5 stages
- **Sahara FAQ** — Expandable FAQ section with 8 items
- **Mobile-first design** — Bottom nav, safe area support, responsive layout
- **Stripe checkout integration** — Free/Pro tier pricing with checkout flow

This PR completes the data collection/migration requirement by wiring up the existing `sync-service.ts` into the frontend components:

- Start periodic sync on app mount (every 30s when active)
- Schedule sync after new chat messages in ChatPage
- Schedule sync after journey milestone toggles in JourneyPage
- Sync on page unload via `sendBeacon` for reliability

## Acceptance Criteria Status
- [x] React app accessible at u.joinsahara.com (Vite SPA with vercel.json)
- [x] Fully responsive, mobile-first design
- [x] Chat/Talk with Fred feature
- [x] Founder Journey section
- [x] Sahara FAQ section
- [x] Data collection mechanism with migration support (this PR)
- [x] No disruption to existing workflows (separate Vite app in funnel/)

## Test plan
- [x] `npm run build` passes in funnel/ directory (tsc + vite build)
- [x] Main app TypeScript check passes (`npx tsc --noEmit`)
- [ ] Verify sync works with VITE_SAHARA_API_URL configured
- [ ] Test on mobile viewports (375px, 390px, 414px)

Linear: https://linear.app/ai-acrobatics/issue/AI-2264/frontend-build-funnel-version-at-ujoinsaharacom-react-mobile-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)