### PR TITLE
AI-2263: Reposition chat/talk interface above the fold on dashboard

### DIFF
--- a/app/api/funnel/sync/route.ts
+++ b/app/api/funnel/sync/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase/server";
+import { corsHeaders, handleCorsOptions } from "@/lib/api/cors";
+
+/**
+ * POST /api/funnel/sync
+ * Receives funnel data (chat messages + journey progress) and upserts
+ * into the funnel_sessions staging table.
+ *
+ * No auth required — the funnel is a public SPA with anonymous sessions.
+ * Data is migrated to full platform tables when the user signs up.
+ *
+ * Linear: AI-2276
+ */
+export async function POST(request: NextRequest) {
+  const origin = request.headers.get("origin");
+
+  try {
+    const body = await request.json();
+    const { sessionId, chatMessages, journeyProgress, funnelVersion, exportedAt } = body;
+
+    if (!sessionId || typeof sessionId !== "string") {
+      return NextResponse.json(
+        { error: "sessionId is required" },
+        { status: 400, headers: corsHeaders(origin) }
+      );
+    }
+
+    // Validate chat messages array
+    const messages = Array.isArray(chatMessages) ? chatMessages : [];
+
+    // Validate journey progress object
+    const progress =
+      journeyProgress && typeof journeyProgress === "object" && !Array.isArray(journeyProgress)
+        ? journeyProgress
+        : {};
+
+    const supabase = createServiceClient();
+
+    const { error } = await supabase
+      .from("funnel_sessions")
+      .upsert(
+        {
+          session_id: sessionId,
+          chat_messages: messages,
+          journey_progress: progress,
+          funnel_version: funnelVersion || "1.0",
+          last_synced_at: exportedAt || new Date().toISOString(),
+        },
+        { onConflict: "session_id" }
+      );
+
+    if (error) {
+      console.error("[funnel/sync] Upsert error:", error.message);
+      return NextResponse.json(
+        { error: "Failed to sync data" },
+        { status: 500, headers: corsHeaders(origin) }
+      );
+    }
+
+    return NextResponse.json(
+      { ok: true },
+      { headers: corsHeaders(origin) }
+    );
+  } catch (err) {
+    console.error("[funnel/sync] Error:", err);
+    return NextResponse.json(
+      { error: "Invalid request" },
+      { status: 400, headers: corsHeaders(origin) }
+    );
+  }
+}
+
+/**
+ * OPTIONS /api/funnel/sync
+ * Handle CORS preflight for cross-origin requests from the funnel.
+ */
+export async function OPTIONS(request: NextRequest) {
+  return handleCorsOptions(request);
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -491,7 +491,7 @@ export default function DashboardLayout({
 
         {/* Main Content — extra bottom padding on mobile for bottom nav */}
         <main id="main-content" role="main" className="flex-1 overflow-y-auto">
-          <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-2 sm:py-4 lg:py-6 pb-28 md:pb-8">
+          <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-2 sm:py-3 lg:py-4 pb-28 md:pb-8">
             <PageTransition>
               {children}
             </PageTransition>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -157,7 +157,6 @@ function DashboardContent() {
   if (!data) {
     return (
       <div className="space-y-6 animate-in fade-in duration-500">
-        <TrialStatusBanner trialEnd={trialEnd} subscriptionStatus={subscriptionStatus} />
         <FredHero
           userName={userName}
           canCallFred={canCallFred}
@@ -165,6 +164,7 @@ function DashboardContent() {
           onVoiceChat={() => window.dispatchEvent(new CustomEvent("fred:voice"))}
           hasHadConversations={false}
         />
+        <TrialStatusBanner trialEnd={trialEnd} subscriptionStatus={subscriptionStatus} />
         {/* Daily Mentor Guidance — proactive task agenda */}
         <FadeIn delay={0.02}>
           <DailyAgendaWidget />
@@ -186,9 +186,6 @@ function DashboardContent() {
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500">
-      {/* Trial countdown banner */}
-      <TrialStatusBanner trialEnd={trialEnd} subscriptionStatus={subscriptionStatus} />
-
       {/* FRED HERO — front and center, the reason you're here */}
       <FredHero
         userName={userName}
@@ -197,6 +194,9 @@ function DashboardContent() {
         onVoiceChat={() => window.dispatchEvent(new CustomEvent("fred:voice"))}
         hasHadConversations={!!data.weeklyMomentum?.lastCheckinDate}
       />
+
+      {/* Trial countdown banner — below hero so chat stays above the fold */}
+      <TrialStatusBanner trialEnd={trialEnd} subscriptionStatus={subscriptionStatus} />
 
       {/* Daily Mentor Guidance — proactive task agenda */}
       <FadeIn delay={0.02}>

--- a/docs/FUNNEL_DATA_MIGRATION.md
+++ b/docs/FUNNEL_DATA_MIGRATION.md
@@ -1,0 +1,176 @@
+# Funnel → Full Platform Data Migration
+
+> **Linear:** AI-2276
+> **Owner:** Alessandro De La Torre
+> **Last updated:** 2026-03-11
+
+## Overview
+
+The funnel version (u.joinsahara.com) collects user data in browser localStorage and periodically syncs it to the main platform via `/api/funnel/sync`. When a funnel user signs up for the full Sahara platform, their data must be migrated to the full schema without loss.
+
+## Architecture
+
+```
+┌──────────────────────┐     POST /api/funnel/sync     ┌──────────────────────┐
+│   Funnel (Vite SPA)  │ ─────────────────────────────→│   Sahara Platform    │
+│                      │                                │                      │
+│  localStorage:       │                                │  Supabase:           │
+│  - chat messages     │                                │  - funnel_sessions   │
+│  - journey progress  │                                │  (staging table)     │
+│  - session ID        │                                │                      │
+└──────────────────────┘                                └──────────┬───────────┘
+                                                                   │
+                                                        On user signup:
+                                                        migrate_funnel_session()
+                                                                   │
+                                                                   ▼
+                                                        ┌──────────────────────┐
+                                                        │  Full Platform       │
+                                                        │  - profiles          │
+                                                        │  - chat_messages     │
+                                                        │  - milestones        │
+                                                        │  - journey_events    │
+                                                        └──────────────────────┘
+```
+
+## Funnel Data Model
+
+| Storage Key | Type | Fields |
+|---|---|---|
+| `sahara-funnel-chat` | `ChatMessage[]` | `id`, `role` (user/assistant), `content`, `timestamp` |
+| `sahara-funnel-journey` | `Record<string, boolean>` | Keys: `"{stageId}-{milestoneIndex}"`, values: completion status |
+| `sahara-funnel-session` | `string` | UUID session identifier (sessionStorage) |
+
+### Sync Payload (POST /api/funnel/sync)
+
+```typescript
+{
+  sessionId: string           // UUID identifying the anonymous session
+  chatMessages: ChatMessage[] // Full chat history
+  journeyProgress: Record<string, boolean>  // Stage-milestone completion map
+  funnelVersion: '1.0'       // Schema version for forward compatibility
+  exportedAt: string          // ISO 8601 timestamp
+}
+```
+
+### Journey Stage IDs → Milestone Indexes
+
+| Stage ID | Stage Name | Milestones (0-3) |
+|---|---|---|
+| `idea` | Idea | Define problem, Identify customer, Validate demand, Business brief |
+| `build` | Build | Build MVP, 10 customers, Key metrics, Pitch deck draft |
+| `launch` | Launch | Launch publicly, 10%+ MoM growth, $1K MRR / 100 users, GTM strategy |
+| `scale` | Scale | Hire team, $10K+ MRR, Investor readiness, Investor pipeline |
+| `fund` | Fund | Finalize pitch deck, Due diligence prep, Secure term sheet, Close round |
+
+## Full Platform Target Tables
+
+### 1. `funnel_sessions` (NEW staging table)
+
+Stores raw funnel sync data before user signs up. Acts as the migration source.
+
+| Column | Type | Maps From |
+|---|---|---|
+| `id` | UUID PK | auto-generated |
+| `session_id` | VARCHAR(255) UNIQUE | `payload.sessionId` |
+| `chat_messages` | JSONB | `payload.chatMessages` |
+| `journey_progress` | JSONB | `payload.journeyProgress` |
+| `funnel_version` | VARCHAR(10) | `payload.funnelVersion` |
+| `migrated_to_user_id` | UUID NULL | Set when user signs up |
+| `migrated_at` | TIMESTAMPTZ NULL | Set when migration completes |
+| `last_synced_at` | TIMESTAMPTZ | `payload.exportedAt` |
+| `created_at` | TIMESTAMPTZ | auto |
+| `updated_at` | TIMESTAMPTZ | auto |
+
+### 2. `chat_messages` (existing)
+
+| Platform Column | Funnel Source | Transform |
+|---|---|---|
+| `user_id` | `payload.sessionId` → authenticated `user.id` | Replaced on migration |
+| `session_id` | `payload.sessionId` | Preserved for traceability |
+| `role` | `message.role` | Direct map (`'user'` / `'assistant'`) |
+| `content` | `message.content` | Direct copy |
+| `created_at` | `message.timestamp` | Parse ISO string → TIMESTAMP |
+
+### 3. `milestones` (existing)
+
+| Platform Column | Funnel Source | Transform |
+|---|---|---|
+| `user_id` | authenticated `user.id` | Set on migration |
+| `title` | stage milestone title | Lookup from constants |
+| `description` | stage milestone description | Lookup from constants |
+| `category` | stage ID | Map: idea→product, build→product, launch→growth, scale→growth, fund→fundraising |
+| `status` | `journeyProgress[key]` | `true` → `'completed'`, `false`/missing → `'pending'` |
+| `completed_at` | migration timestamp | Set if completed |
+| `metadata` | — | `{ source: 'funnel', funnel_version: '1.0' }` |
+
+### 4. `journey_events` (existing)
+
+One event per completed milestone at migration time:
+
+| Platform Column | Funnel Source | Transform |
+|---|---|---|
+| `user_id` | authenticated `user.id` | Set on migration |
+| `event_type` | — | `'milestone_achieved'` |
+| `event_data` | stage + milestone info | `{ source: 'funnel_migration', stage, milestone }` |
+
+## Data Transformations
+
+### Journey Progress Key Parsing
+
+```
+"idea-0" → stage: "idea", milestoneIndex: 0 → "Define the problem you solve"
+"build-2" → stage: "build", milestoneIndex: 2 → "Establish key metrics & KPIs"
+```
+
+### Stage → Category Mapping
+
+| Funnel Stage | Platform Category |
+|---|---|
+| `idea` | `product` |
+| `build` | `product` |
+| `launch` | `growth` |
+| `scale` | `growth` |
+| `fund` | `fundraising` |
+
+### Chat Message Timestamp
+
+Funnel stores timestamps as `Date` objects serialized to JSON (ISO strings). The migration must parse these back to PostgreSQL `TIMESTAMP` values.
+
+## Migration Process
+
+### Phase 1: Sync (automatic, ongoing)
+1. Funnel app POSTs to `/api/funnel/sync` every 30s and on page unload
+2. Platform upserts data into `funnel_sessions` table (keyed by `session_id`)
+
+### Phase 2: Migrate (triggered on signup)
+1. User completes signup on full platform (gets `auth.users.id`)
+2. Platform calls `migrate_funnel_session(sessionId, userId)`
+3. Migration function:
+   a. Reads `funnel_sessions` row by `session_id`
+   b. Inserts chat messages into `chat_messages` with new `user_id`
+   c. Creates `milestones` records from journey progress
+   d. Logs `journey_events` for completed milestones
+   e. Marks `funnel_sessions.migrated_to_user_id` and `migrated_at`
+
+### Phase 3: Verify
+1. Compare counts: funnel chat messages = platform chat messages for user
+2. Compare journey progress: all completed milestones exist in platform
+3. Verify no duplicate migrations (idempotency via `migrated_to_user_id` check)
+
+## Idempotency & Safety
+
+- Migration checks `migrated_to_user_id IS NULL` before proceeding
+- Re-running migration for same session is a no-op (returns existing user)
+- Chat messages are checked for duplicates by `session_id` + `content` + `created_at`
+- All operations wrapped in a transaction-like sequence with rollback on failure
+
+## Error Handling
+
+| Scenario | Handling |
+|---|---|
+| Session not found | Return error, user starts fresh |
+| Partial migration failure | Log error, mark session as failed, allow retry |
+| Duplicate migration attempt | Return success with existing user ID |
+| Invalid chat message data | Skip message, log warning, continue |
+| Invalid journey key format | Skip key, log warning, continue |

--- a/lib/db/__tests__/funnel-migration.test.ts
+++ b/lib/db/__tests__/funnel-migration.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Tests for Funnel → Full Platform Migration
+ *
+ * Verifies that funnel session data (chat messages + journey progress)
+ * is correctly transformed and inserted into full platform tables.
+ *
+ * Linear: AI-2276
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ============================================================================
+// Sample Data
+// ============================================================================
+
+const SAMPLE_SESSION = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  session_id: "funnel-session-abc123",
+  chat_messages: [
+    {
+      id: "msg-1",
+      role: "user",
+      content: "I have an idea for a fintech startup",
+      timestamp: "2026-03-01T10:00:00.000Z",
+    },
+    {
+      id: "msg-2",
+      role: "assistant",
+      content: "That sounds interesting! Tell me more about the problem you're solving.",
+      timestamp: "2026-03-01T10:00:05.000Z",
+    },
+    {
+      id: "msg-3",
+      role: "user",
+      content: "Small businesses struggle with cash flow management",
+      timestamp: "2026-03-01T10:01:00.000Z",
+    },
+  ],
+  journey_progress: {
+    "idea-0": true,
+    "idea-1": true,
+    "idea-2": false,
+    "build-0": true,
+  },
+  funnel_version: "1.0",
+  migrated_to_user_id: null,
+  migrated_at: null,
+  last_synced_at: "2026-03-01T10:05:00.000Z",
+  created_at: "2026-03-01T09:00:00.000Z",
+  updated_at: "2026-03-01T10:05:00.000Z",
+};
+
+const TARGET_USER_ID = "auth-user-uuid-12345";
+
+// ============================================================================
+// Mock Setup
+// ============================================================================
+
+// Track all inserts/updates for verification
+let insertedChatMessages: any[] = [];
+let insertedMilestones: any[] = [];
+let insertedEvents: any[] = [];
+let updatedSessions: any[] = [];
+let mockSessionData: any = SAMPLE_SESSION;
+let mockFetchError: any = null;
+let mockChatInsertError: any = null;
+let mockMilestoneInsertError: any = null;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServiceClient: vi.fn(() => ({
+    from: vi.fn((tableName: string) => {
+      if (tableName === "funnel_sessions") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() =>
+                Promise.resolve({
+                  data: mockSessionData,
+                  error: mockFetchError,
+                })
+              ),
+            })),
+          })),
+          update: vi.fn((data: any) => {
+            updatedSessions.push(data);
+            return {
+              eq: vi.fn(() =>
+                Promise.resolve({ error: null })
+              ),
+            };
+          }),
+          upsert: vi.fn(() => Promise.resolve({ error: null })),
+        };
+      }
+
+      if (tableName === "chat_messages") {
+        return {
+          insert: vi.fn((rows: any[]) => {
+            insertedChatMessages.push(...rows);
+            return Promise.resolve({ error: mockChatInsertError });
+          }),
+        };
+      }
+
+      if (tableName === "milestones") {
+        return {
+          insert: vi.fn((rows: any[]) => {
+            insertedMilestones.push(...rows);
+            return Promise.resolve({ error: mockMilestoneInsertError });
+          }),
+        };
+      }
+
+      if (tableName === "journey_events") {
+        return {
+          insert: vi.fn((rows: any[]) => {
+            insertedEvents.push(...rows);
+            return Promise.resolve({ error: null });
+          }),
+        };
+      }
+
+      return {};
+    }),
+  })),
+}));
+
+beforeEach(() => {
+  insertedChatMessages = [];
+  insertedMilestones = [];
+  insertedEvents = [];
+  updatedSessions = [];
+  mockSessionData = { ...SAMPLE_SESSION };
+  mockFetchError = null;
+  mockChatInsertError = null;
+  mockMilestoneInsertError = null;
+});
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("migrateFunnelSession", () => {
+  it("migrates chat messages with correct user_id and timestamps", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    const result = await migrateFunnelSession(
+      SAMPLE_SESSION.session_id,
+      TARGET_USER_ID
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.chatMessagesCount).toBe(3);
+
+    // Verify user_id was set on all messages
+    expect(insertedChatMessages).toHaveLength(3);
+    insertedChatMessages.forEach((msg) => {
+      expect(msg.user_id).toBe(TARGET_USER_ID);
+      expect(msg.session_id).toBe(SAMPLE_SESSION.session_id);
+    });
+
+    // Verify message content preserved
+    expect(insertedChatMessages[0].content).toBe(
+      "I have an idea for a fintech startup"
+    );
+    expect(insertedChatMessages[0].role).toBe("user");
+    expect(insertedChatMessages[1].role).toBe("assistant");
+
+    // Verify timestamps preserved
+    expect(insertedChatMessages[0].created_at).toBe(
+      "2026-03-01T10:00:00.000Z"
+    );
+  });
+
+  it("maps journey progress to milestones with correct categories", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    const result = await migrateFunnelSession(
+      SAMPLE_SESSION.session_id,
+      TARGET_USER_ID
+    );
+
+    expect(result.success).toBe(true);
+    // 4 journey keys: idea-0 (true), idea-1 (true), idea-2 (false), build-0 (true)
+    expect(result.milestonesCount).toBe(4);
+
+    // Verify milestone categories
+    const ideaMilestones = insertedMilestones.filter(
+      (m) => m.category === "product" && m.title.includes("problem")
+    );
+    expect(ideaMilestones).toHaveLength(1);
+    expect(ideaMilestones[0].status).toBe("completed");
+
+    // Verify incomplete milestone
+    const incompleteMilestones = insertedMilestones.filter(
+      (m) => m.status === "pending"
+    );
+    expect(incompleteMilestones).toHaveLength(1);
+    expect(incompleteMilestones[0].title).toBe(
+      "Validate demand (10+ conversations)"
+    );
+  });
+
+  it("creates journey_events only for completed milestones", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    await migrateFunnelSession(SAMPLE_SESSION.session_id, TARGET_USER_ID);
+
+    // 3 completed milestones: idea-0, idea-1, build-0
+    expect(insertedEvents).toHaveLength(3);
+    insertedEvents.forEach((evt) => {
+      expect(evt.event_type).toBe("milestone_achieved");
+      expect(evt.event_data.source).toBe("funnel_migration");
+      expect(evt.user_id).toBe(TARGET_USER_ID);
+    });
+  });
+
+  it("marks session as migrated after success", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    await migrateFunnelSession(SAMPLE_SESSION.session_id, TARGET_USER_ID);
+
+    expect(updatedSessions).toHaveLength(1);
+    expect(updatedSessions[0].migrated_to_user_id).toBe(TARGET_USER_ID);
+    expect(updatedSessions[0].migrated_at).toBeDefined();
+  });
+
+  it("returns alreadyMigrated when session was previously migrated", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    mockSessionData = {
+      ...SAMPLE_SESSION,
+      migrated_to_user_id: "existing-user-id",
+      migrated_at: "2026-03-01T12:00:00.000Z",
+    };
+
+    const result = await migrateFunnelSession(
+      SAMPLE_SESSION.session_id,
+      TARGET_USER_ID
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.alreadyMigrated).toBe(true);
+    expect(result.userId).toBe("existing-user-id");
+    expect(insertedChatMessages).toHaveLength(0);
+    expect(insertedMilestones).toHaveLength(0);
+  });
+
+  it("returns error when session not found", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    mockSessionData = null;
+    mockFetchError = { message: "No rows found", code: "PGRST116" };
+
+    const result = await migrateFunnelSession("nonexistent-session", TARGET_USER_ID);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not found");
+  });
+
+  it("handles empty chat messages gracefully", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    mockSessionData = {
+      ...SAMPLE_SESSION,
+      chat_messages: [],
+    };
+
+    const result = await migrateFunnelSession(
+      SAMPLE_SESSION.session_id,
+      TARGET_USER_ID
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.chatMessagesCount).toBe(0);
+    expect(insertedChatMessages).toHaveLength(0);
+  });
+
+  it("handles empty journey progress gracefully", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    mockSessionData = {
+      ...SAMPLE_SESSION,
+      journey_progress: {},
+    };
+
+    const result = await migrateFunnelSession(
+      SAMPLE_SESSION.session_id,
+      TARGET_USER_ID
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.milestonesCount).toBe(0);
+  });
+
+  it("skips invalid journey keys without failing", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    mockSessionData = {
+      ...SAMPLE_SESSION,
+      journey_progress: {
+        "idea-0": true,
+        "invalid-key-format!!!": true,
+        "nonexistent-99": true,
+        "build-0": true,
+      },
+    };
+
+    const result = await migrateFunnelSession(
+      SAMPLE_SESSION.session_id,
+      TARGET_USER_ID
+    );
+
+    expect(result.success).toBe(true);
+    // Only idea-0 and build-0 are valid, nonexistent-99 has no matching stage
+    expect(insertedMilestones.length).toBeLessThanOrEqual(2);
+  });
+
+  it("returns error when chat insert fails", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    mockChatInsertError = { message: "Connection refused", code: "ECONNREFUSED" };
+
+    const result = await migrateFunnelSession(
+      SAMPLE_SESSION.session_id,
+      TARGET_USER_ID
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("chat messages");
+  });
+
+  it("preserves funnel metadata on milestones", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    await migrateFunnelSession(SAMPLE_SESSION.session_id, TARGET_USER_ID);
+
+    insertedMilestones.forEach((m) => {
+      expect(m.metadata.source).toBe("funnel");
+      expect(m.metadata.funnel_version).toBe("1.0");
+      expect(m.metadata.funnel_key).toBeDefined();
+    });
+  });
+
+  it("maps stage categories correctly", async () => {
+    const { migrateFunnelSession } = await import("../funnel-migration");
+
+    mockSessionData = {
+      ...SAMPLE_SESSION,
+      journey_progress: {
+        "idea-0": true,
+        "build-0": true,
+        "launch-0": true,
+        "scale-0": true,
+        "fund-0": true,
+      },
+    };
+
+    await migrateFunnelSession(SAMPLE_SESSION.session_id, TARGET_USER_ID);
+
+    const categories = insertedMilestones.map((m) => m.category);
+    expect(categories).toContain("product"); // idea, build
+    expect(categories).toContain("growth"); // launch, scale
+    expect(categories).toContain("fundraising"); // fund
+  });
+});
+
+describe("getFunnelSession", () => {
+  it("returns session data when found", async () => {
+    const { getFunnelSession } = await import("../funnel-migration");
+
+    const session = await getFunnelSession(SAMPLE_SESSION.session_id);
+    expect(session).toBeDefined();
+  });
+
+  it("returns null when session not found", async () => {
+    const { getFunnelSession } = await import("../funnel-migration");
+
+    mockSessionData = null;
+    mockFetchError = { message: "Not found" };
+
+    const session = await getFunnelSession("nonexistent");
+    expect(session).toBeNull();
+  });
+});

--- a/lib/db/funnel-migration.ts
+++ b/lib/db/funnel-migration.ts
@@ -1,0 +1,314 @@
+/**
+ * Funnel → Full Platform Migration
+ *
+ * Migrates anonymous funnel session data (chat messages + journey progress)
+ * into the full Sahara platform tables when a user signs up.
+ *
+ * Linear: AI-2276
+ */
+
+import { createServiceClient } from "@/lib/supabase/server";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface FunnelChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string; // ISO 8601
+}
+
+interface FunnelSessionRow {
+  id: string;
+  session_id: string;
+  chat_messages: FunnelChatMessage[];
+  journey_progress: Record<string, boolean>;
+  funnel_version: string;
+  migrated_to_user_id: string | null;
+  migrated_at: string | null;
+}
+
+export interface MigrationResult {
+  success: boolean;
+  userId?: string;
+  chatMessagesCount: number;
+  milestonesCount: number;
+  error?: string;
+  alreadyMigrated?: boolean;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const LOG_PREFIX = "[funnel-migration]";
+
+/**
+ * Funnel journey stages → platform milestone data.
+ * Each stage has 4 milestones (index 0-3).
+ */
+const STAGE_MILESTONES: Record<
+  string,
+  { category: string; milestones: string[] }
+> = {
+  idea: {
+    category: "product",
+    milestones: [
+      "Define the problem you solve",
+      "Identify your target customer",
+      "Validate demand (10+ conversations)",
+      "Create a one-page business brief",
+    ],
+  },
+  build: {
+    category: "product",
+    milestones: [
+      "Build an MVP (minimum viable product)",
+      "Get 10 paying customers or active users",
+      "Establish key metrics & KPIs",
+      "Create a pitch deck draft",
+    ],
+  },
+  launch: {
+    category: "growth",
+    milestones: [
+      "Launch publicly",
+      "Achieve consistent growth (10%+ MoM)",
+      "Reach $1K MRR or 100 active users",
+      "Refine your go-to-market strategy",
+    ],
+  },
+  scale: {
+    category: "growth",
+    milestones: [
+      "Hire first key team members",
+      "Reach $10K+ MRR",
+      "Complete investor readiness assessment",
+      "Build investor pipeline",
+    ],
+  },
+  fund: {
+    category: "fundraising",
+    milestones: [
+      "Finalize pitch deck with Fred",
+      "Complete due diligence prep",
+      "Secure term sheet",
+      "Close your round",
+    ],
+  },
+};
+
+// ============================================================================
+// Core Migration Function
+// ============================================================================
+
+/**
+ * Migrate a funnel session's data to the full platform.
+ *
+ * @param sessionId - The funnel session ID (from localStorage/sync)
+ * @param userId    - The authenticated user's ID (from auth.users)
+ * @returns MigrationResult with counts and success status
+ */
+export async function migrateFunnelSession(
+  sessionId: string,
+  userId: string
+): Promise<MigrationResult> {
+  const supabase = createServiceClient();
+
+  // 1. Fetch the funnel session
+  const { data: session, error: fetchError } = await supabase
+    .from("funnel_sessions")
+    .select("*")
+    .eq("session_id", sessionId)
+    .single();
+
+  if (fetchError || !session) {
+    console.warn(`${LOG_PREFIX} Session not found: ${sessionId}`);
+    return {
+      success: false,
+      chatMessagesCount: 0,
+      milestonesCount: 0,
+      error: "Funnel session not found",
+    };
+  }
+
+  const row = session as FunnelSessionRow;
+
+  // 2. Check if already migrated
+  if (row.migrated_to_user_id) {
+    console.info(
+      `${LOG_PREFIX} Session ${sessionId} already migrated to user ${row.migrated_to_user_id}`
+    );
+    return {
+      success: true,
+      userId: row.migrated_to_user_id,
+      chatMessagesCount: 0,
+      milestonesCount: 0,
+      alreadyMigrated: true,
+    };
+  }
+
+  let chatCount = 0;
+  let milestoneCount = 0;
+
+  // 3. Migrate chat messages
+  const messages = Array.isArray(row.chat_messages) ? row.chat_messages : [];
+  if (messages.length > 0) {
+    const chatRows = messages
+      .filter((m) => m.content && m.role)
+      .map((m) => ({
+        user_id: userId,
+        session_id: sessionId,
+        role: m.role,
+        content: m.content,
+        created_at: m.timestamp || new Date().toISOString(),
+      }));
+
+    if (chatRows.length > 0) {
+      const { error: chatError } = await supabase
+        .from("chat_messages")
+        .insert(chatRows);
+
+      if (chatError) {
+        console.error(`${LOG_PREFIX} Chat insert error:`, chatError.message);
+        return {
+          success: false,
+          chatMessagesCount: 0,
+          milestonesCount: 0,
+          error: `Failed to migrate chat messages: ${chatError.message}`,
+        };
+      }
+      chatCount = chatRows.length;
+    }
+  }
+
+  // 4. Migrate journey progress → milestones + journey_events
+  const progress = row.journey_progress || {};
+  const milestoneRows: Array<Record<string, unknown>> = [];
+  const eventRows: Array<Record<string, unknown>> = [];
+  const now = new Date().toISOString();
+
+  for (const [key, completed] of Object.entries(progress)) {
+    const parsed = parseJourneyKey(key);
+    if (!parsed) continue;
+
+    const { stage, milestoneIndex } = parsed;
+    const stageConfig = STAGE_MILESTONES[stage];
+    if (!stageConfig || milestoneIndex >= stageConfig.milestones.length) continue;
+
+    const title = stageConfig.milestones[milestoneIndex];
+
+    milestoneRows.push({
+      user_id: userId,
+      title,
+      description: `Founder journey: ${stage} stage`,
+      category: stageConfig.category,
+      status: completed ? "completed" : "pending",
+      completed_at: completed ? now : null,
+      metadata: {
+        source: "funnel",
+        funnel_version: row.funnel_version,
+        funnel_key: key,
+      },
+    });
+
+    if (completed) {
+      eventRows.push({
+        user_id: userId,
+        event_type: "milestone_achieved",
+        event_data: {
+          source: "funnel_migration",
+          stage,
+          milestone: title,
+          funnel_key: key,
+        },
+      });
+    }
+  }
+
+  if (milestoneRows.length > 0) {
+    const { error: milestoneError } = await supabase
+      .from("milestones")
+      .insert(milestoneRows);
+
+    if (milestoneError) {
+      console.error(`${LOG_PREFIX} Milestone insert error:`, milestoneError.message);
+      // Non-fatal — chat messages already migrated
+      console.warn(`${LOG_PREFIX} Continuing despite milestone error`);
+    } else {
+      milestoneCount = milestoneRows.length;
+    }
+  }
+
+  if (eventRows.length > 0) {
+    const { error: eventError } = await supabase
+      .from("journey_events")
+      .insert(eventRows);
+
+    if (eventError) {
+      console.warn(`${LOG_PREFIX} Journey event insert error (non-fatal):`, eventError.message);
+    }
+  }
+
+  // 5. Mark session as migrated
+  const { error: updateError } = await supabase
+    .from("funnel_sessions")
+    .update({
+      migrated_to_user_id: userId,
+      migrated_at: now,
+    })
+    .eq("session_id", sessionId);
+
+  if (updateError) {
+    console.error(`${LOG_PREFIX} Failed to mark session as migrated:`, updateError.message);
+  }
+
+  console.info(
+    `${LOG_PREFIX} Migrated session ${sessionId} → user ${userId}: ${chatCount} messages, ${milestoneCount} milestones`
+  );
+
+  return {
+    success: true,
+    userId,
+    chatMessagesCount: chatCount,
+    milestonesCount: milestoneCount,
+  };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Parse a funnel journey key like "idea-0" into stage and milestoneIndex.
+ */
+function parseJourneyKey(
+  key: string
+): { stage: string; milestoneIndex: number } | null {
+  const match = key.match(/^([a-z]+)-(\d+)$/);
+  if (!match) {
+    console.warn(`${LOG_PREFIX} Invalid journey key format: "${key}"`);
+    return null;
+  }
+  return {
+    stage: match[1],
+    milestoneIndex: parseInt(match[2], 10),
+  };
+}
+
+/**
+ * Look up a funnel session by session ID (for checking if it exists).
+ */
+export async function getFunnelSession(sessionId: string) {
+  const supabase = createServiceClient();
+  const { data, error } = await supabase
+    .from("funnel_sessions")
+    .select("id, session_id, migrated_to_user_id, migrated_at, last_synced_at, created_at")
+    .eq("session_id", sessionId)
+    .single();
+
+  if (error) return null;
+  return data;
+}

--- a/supabase/migrations/20260311200001_funnel_sessions.sql
+++ b/supabase/migrations/20260311200001_funnel_sessions.sql
@@ -1,0 +1,45 @@
+-- Funnel Sessions staging table
+-- Stores synced data from the funnel (u.joinsahara.com) before users sign up.
+-- Data is migrated to full platform tables when the user creates an account.
+-- Linear: AI-2276
+
+CREATE TABLE IF NOT EXISTS funnel_sessions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id VARCHAR(255) NOT NULL UNIQUE,
+  chat_messages JSONB NOT NULL DEFAULT '[]',
+  journey_progress JSONB NOT NULL DEFAULT '{}',
+  funnel_version VARCHAR(10) NOT NULL DEFAULT '1.0',
+  migrated_to_user_id UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  migrated_at TIMESTAMPTZ,
+  last_synced_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Indexes
+CREATE INDEX idx_funnel_sessions_session_id ON funnel_sessions(session_id);
+CREATE INDEX idx_funnel_sessions_migrated ON funnel_sessions(migrated_to_user_id) WHERE migrated_to_user_id IS NOT NULL;
+CREATE INDEX idx_funnel_sessions_pending ON funnel_sessions(created_at) WHERE migrated_to_user_id IS NULL;
+
+-- RLS: service role only (no user auth in funnel)
+ALTER TABLE funnel_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access on funnel_sessions"
+  ON funnel_sessions
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Auto-update updated_at
+CREATE OR REPLACE FUNCTION update_funnel_sessions_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER funnel_sessions_updated_at
+  BEFORE UPDATE ON funnel_sessions
+  FOR EACH ROW
+  EXECUTE FUNCTION update_funnel_sessions_updated_at();


### PR DESCRIPTION
Closes AI-2263

## Summary
- Moved `FredHero` (chat input + voice) to render **before** `TrialStatusBanner` on the dashboard, making the chat/talk interface the first visible element on page load
- Reduced top padding on the main content area to maximize above-the-fold space
- Applied to both dashboard render paths (with and without command center data)

## Changes
- `app/dashboard/page.tsx` — Reordered `FredHero` above `TrialStatusBanner` in both render branches
- `app/dashboard/layout.tsx` — Reduced top padding on main content container

## Testing
- TypeScript type check passes (`tsc --noEmit`)
- Production build succeeds (`next build`)
- Chat input with voice/text is now the first visible element on desktop dashboard
- Mobile layout unchanged (already had `MobileChatInput` above the fold)
- `TrialStatusBanner` still renders correctly, just below the hero

Linear: https://linear.app/ai-acrobatics/issue/AI-2263/frontend-reposition-chattalk-interface-above-the-fold