### PR TITLE
AI-2212: Set up Stripe payment integration for funnel version account upgrades

### DIFF
--- a/app/api/funnel/checkout/route.ts
+++ b/app/api/funnel/checkout/route.ts
@@ -12,6 +12,7 @@ import { corsHeaders, handleCorsOptions } from "@/lib/api/cors";
  * Stripe Checkout handles collecting payment info and creating the customer.
  *
  * After checkout, the user is redirected to the main app to complete signup.
+ * The /api/funnel/reconcile endpoint then links the subscription to the real user.
  */
 export async function POST(request: NextRequest) {
   const origin = request.headers.get("origin");
@@ -31,16 +32,18 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
     const { tier, email } = body;
 
-    // Map tier to plan -- only Pro (fundraising) is available from the funnel
+    // Map tier to plan
     const TIER_TO_PLAN_KEY: Record<string, keyof typeof PLANS> = {
       PRO: "FUNDRAISING",
       FUNDRAISING: "FUNDRAISING",
+      STUDIO: "VENTURE_STUDIO",
+      VENTURE_STUDIO: "VENTURE_STUDIO",
     };
 
     const planKey = TIER_TO_PLAN_KEY[(tier || "PRO").toUpperCase()];
     if (!planKey) {
       return NextResponse.json(
-        { error: "Invalid tier. Only 'pro' is available from the funnel." },
+        { error: "Invalid tier. Available tiers: 'pro', 'studio'." },
         { status: 400, headers: corsHeaders(origin) }
       );
     }
@@ -62,8 +65,9 @@ export async function POST(request: NextRequest) {
     // After cancellation, redirect back to the funnel.
     const sessionParams: Parameters<typeof createCheckoutSession>[0] = {
       priceId,
-      userId: "funnel-pending", // Placeholder -- webhook will reconcile after signup
-      successUrl: `${baseUrl}/onboarding?checkout=success&tier=${plan.id}&session_id={CHECKOUT_SESSION_ID}`,
+      userId: "funnel-pending", // Placeholder -- reconcile endpoint links to real user after signup
+      customerEmail: email || undefined,
+      successUrl: `${baseUrl}/onboarding?checkout=success&tier=${plan.id}&source=funnel&session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${funnelUrl}/?checkout=canceled`,
     };
 

--- a/app/api/funnel/reconcile/route.ts
+++ b/app/api/funnel/reconcile/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth";
+import {
+  getCheckoutSession,
+  updateSubscriptionMetadata,
+} from "@/lib/stripe/server";
+import { createOrUpdateSubscription } from "@/lib/db/subscriptions";
+import { getPlanByPriceId } from "@/lib/stripe/config";
+import Stripe from "stripe";
+
+/**
+ * POST /api/funnel/reconcile
+ *
+ * Links a funnel Stripe checkout session to an authenticated user.
+ *
+ * Flow:
+ * 1. User pays on funnel (u.joinsahara.com) → Stripe checkout with userId "funnel-pending"
+ * 2. User is redirected to main app onboarding with session_id in URL
+ * 3. User creates account / logs in on main app
+ * 4. Frontend calls this endpoint with the session_id to link the subscription
+ *
+ * Security: Requires authentication — userId comes from server-side session, not client.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await requireAuth();
+
+    const { sessionId } = await request.json();
+
+    if (!sessionId || typeof sessionId !== "string") {
+      return NextResponse.json(
+        { error: "sessionId is required" },
+        { status: 400 }
+      );
+    }
+
+    if (!process.env.STRIPE_SECRET_KEY) {
+      return NextResponse.json(
+        { error: "Stripe not configured", code: "STRIPE_NOT_CONFIGURED" },
+        { status: 503 }
+      );
+    }
+
+    // Retrieve the checkout session from Stripe
+    const session = await getCheckoutSession(sessionId);
+
+    if (!session) {
+      return NextResponse.json(
+        { error: "Checkout session not found" },
+        { status: 404 }
+      );
+    }
+
+    // Verify this is a funnel checkout (client_reference_id = "funnel-pending")
+    if (session.client_reference_id !== "funnel-pending") {
+      // Already reconciled or not a funnel session
+      return NextResponse.json(
+        { error: "Session already reconciled or not a funnel checkout" },
+        { status: 400 }
+      );
+    }
+
+    if (session.status !== "complete") {
+      return NextResponse.json(
+        { error: "Checkout session is not complete" },
+        { status: 400 }
+      );
+    }
+
+    const subscription = session.subscription as Stripe.Subscription | null;
+    if (!subscription) {
+      return NextResponse.json(
+        { error: "No subscription found for this session" },
+        { status: 400 }
+      );
+    }
+
+    const subscriptionId =
+      typeof subscription === "string" ? subscription : subscription.id;
+    const customerId = session.customer as string;
+
+    // Update Stripe subscription metadata with the real userId
+    await updateSubscriptionMetadata(subscriptionId, { userId });
+
+    // Resolve price ID from the subscription
+    const sub =
+      typeof subscription === "string"
+        ? null
+        : subscription;
+    const priceId = sub?.items?.data?.[0]?.price?.id || "";
+    const plan = priceId ? getPlanByPriceId(priceId) : null;
+
+    // Resolve subscription period
+    const subData = sub as unknown as Record<string, unknown> | null;
+    const periodStart = subData?.current_period_start ?? subData?.currentPeriodStart;
+    const periodEnd = subData?.current_period_end ?? subData?.currentPeriodEnd;
+
+    // Create or update the subscription in our DB linked to the real user
+    await createOrUpdateSubscription({
+      userId,
+      stripeCustomerId: typeof customerId === "string" ? customerId : "",
+      stripeSubscriptionId: subscriptionId,
+      stripePriceId: priceId,
+      status: (sub?.status as "active" | "trialing") || "active",
+      currentPeriodStart: periodStart
+        ? new Date((periodStart as number) * 1000)
+        : new Date(),
+      currentPeriodEnd: periodEnd
+        ? new Date((periodEnd as number) * 1000)
+        : new Date(),
+    });
+
+    console.log(
+      `[Funnel Reconcile] Linked session ${sessionId} → user ${userId}, subscription ${subscriptionId}`
+    );
+
+    return NextResponse.json({
+      success: true,
+      plan: plan
+        ? { id: plan.id, name: plan.name, price: plan.price }
+        : null,
+      subscriptionId,
+    });
+  } catch (error) {
+    console.error("[Funnel Reconcile] Error:", error);
+
+    // Return auth errors directly
+    if (error instanceof Response) return error;
+
+    return NextResponse.json(
+      { error: "Failed to reconcile funnel checkout" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -120,6 +120,14 @@ export async function POST(request: NextRequest) {
             session.subscription as string
           );
           let userId = session.client_reference_id;
+
+          // Funnel checkouts use "funnel-pending" as placeholder -- skip DB update,
+          // the /api/funnel/reconcile endpoint will link it after user signs up.
+          if (userId === "funnel-pending") {
+            console.log(`[Webhook] checkout.session.completed: Funnel checkout (pending reconciliation). Session: ${session.id}, Subscription: ${subscription.id}`);
+            break;
+          }
+
           if (!userId) {
             // Fallback: try to resolve userId from subscription metadata or customer ID
             userId = await resolveUserIdFromSubscription(subscription);
@@ -139,14 +147,18 @@ export async function POST(request: NextRequest) {
       case "customer.subscription.updated": {
         const subscription = event.data.object as Stripe.Subscription;
         const userId = await resolveUserIdFromSubscription(subscription);
-        if (userId) {
-          const newTier = getUserTierFromSubscription(subscription);
-          serverTrack(userId, ANALYTICS_EVENTS.SUBSCRIPTION.TIER_CHANGED, { toTier: newTier, priceId: subscription.items.data[0]?.price.id });
-          await handleSubscriptionUpdate(subscription, userId);
-        } else {
-          console.error(`[Webhook] No userId found for subscription ${subscription.id}`);
-          await markEventAsFailed(stripeEvent.id, `No userId found for subscription ${subscription.id}`);
+
+        // Funnel-pending subscriptions will be reconciled via /api/funnel/reconcile
+        if (!userId || userId === "funnel-pending") {
+          if (!userId) {
+            console.log(`[Webhook] ${event.type}: No userId for subscription ${subscription.id} (may be funnel-pending, awaiting reconciliation)`);
+          }
+          break;
         }
+
+        const newTier = getUserTierFromSubscription(subscription);
+        serverTrack(userId, ANALYTICS_EVENTS.SUBSCRIPTION.TIER_CHANGED, { toTier: newTier, priceId: subscription.items.data[0]?.price.id });
+        await handleSubscriptionUpdate(subscription, userId);
         break;
       }
 

--- a/lib/stripe/server.ts
+++ b/lib/stripe/server.ts
@@ -35,12 +35,14 @@ export const stripe = {
 export async function createCheckoutSession({
   priceId,
   customerId,
+  customerEmail,
   userId,
   successUrl,
   cancelUrl,
 }: {
   priceId: string;
   customerId?: string;
+  customerEmail?: string;
   userId: string;
   successUrl: string;
   cancelUrl: string;
@@ -69,6 +71,9 @@ export async function createCheckoutSession({
   // Only include customer if we have one (avoids sending undefined to Stripe)
   if (customerId) {
     sessionParams.customer = customerId;
+  } else if (customerEmail) {
+    // Pre-fill email on Stripe Checkout (used by funnel where user may not have an account)
+    sessionParams.customer_email = customerEmail;
   }
 
   const session = await getStripe().checkout.sessions.create(sessionParams);
@@ -114,4 +119,24 @@ export async function cancelSubscription(subscriptionId: string) {
   return getStripe().subscriptions.update(subscriptionId, {
     cancel_at_period_end: true,
   });
+}
+
+/**
+ * Retrieve a checkout session with expanded subscription and customer data.
+ * Used for post-checkout reconciliation (e.g., funnel -> main app).
+ */
+export async function getCheckoutSession(sessionId: string) {
+  return getStripe().checkout.sessions.retrieve(sessionId, {
+    expand: ["subscription", "customer"],
+  });
+}
+
+/**
+ * Update subscription metadata (e.g., to link a funnel-pending subscription to a real user).
+ */
+export async function updateSubscriptionMetadata(
+  subscriptionId: string,
+  metadata: Record<string, string>
+) {
+  return getStripe().subscriptions.update(subscriptionId, { metadata });
 }


### PR DESCRIPTION
Closes AI-2212

## Summary
- **Studio tier support**: Funnel checkout now supports both Pro ($99/mo) and Studio ($249/mo) tiers (was previously pro-only)
- **Customer email pre-fill**: Pass email to Stripe Checkout so returning users don't have to re-enter it
- **Post-signup reconciliation**: New `/api/funnel/reconcile` endpoint links Stripe checkout sessions to real user accounts after they sign up on the main platform
- **Graceful webhook handling**: Webhook no longer fails on funnel-pending subscriptions — logs and skips instead, waiting for reconciliation
- **Stripe server utilities**: Added `getCheckoutSession()` and `updateSubscriptionMetadata()` for the reconciliation flow

## Payment Flow
1. User clicks upgrade on funnel (u.joinsahara.com)
2. Funnel calls `/api/funnel/checkout` with tier + optional email
3. Stripe Checkout session created with `userId: "funnel-pending"`
4. User completes payment on Stripe's hosted page
5. User redirected to main app onboarding with `session_id` in URL
6. After signup/login, frontend calls `/api/funnel/reconcile` with `session_id`
7. Reconcile endpoint links the Stripe subscription to the real user

## Files Changed
- `lib/stripe/server.ts` — Added `customerEmail` param, `getCheckoutSession()`, `updateSubscriptionMetadata()`
- `app/api/funnel/checkout/route.ts` — Added Studio tier mapping, email passthrough, source tracking
- `app/api/stripe/webhook/route.ts` — Graceful funnel-pending handling in checkout + subscription events
- `app/api/funnel/reconcile/route.ts` — **New** authenticated endpoint for post-signup subscription linking

## Testing
- TypeScript compiles clean (no new errors)
- Funnel app typechecks clean
- All pre-existing tests unaffected

Linear: https://linear.app/ai-acrobatics/issue/AI-2212/backend-set-up-stripe-payment-integration-for-funnel-version-account

🤖 Generated with [Claude Code](https://claude.com/claude-code)