### PR TITLE
PERS-235: Fix login/password reset flow for Sahara emails

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -39,9 +39,18 @@ export async function GET(request: NextRequest) {
     }
 
     console.error("[auth/callback] Code exchange failed:", error.message)
+
+    // Provide specific error hints based on failure type
+    const errorUrl = new URL("/forgot-password", origin)
+    if (error.message.includes("already used") || error.message.includes("consumed")) {
+      errorUrl.searchParams.set("error", "used")
+    } else {
+      errorUrl.searchParams.set("error", "expired")
+    }
+    return NextResponse.redirect(errorUrl)
   }
 
-  // If no code or exchange failed, redirect to forgot-password with error hint
+  // If no code provided, redirect to forgot-password with error hint
   const errorUrl = new URL("/forgot-password", origin)
   errorUrl.searchParams.set("error", "expired")
   return NextResponse.redirect(errorUrl)

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -25,9 +25,10 @@ export async function POST(request: NextRequest) {
     const result = await signIn(email, password);
 
     if (!result.success) {
+      const status = result.error === "EMAIL_NOT_CONFIRMED" ? 403 : 401;
       return NextResponse.json(
-        { error: result.error },
-        { status: 401 }
+        { error: result.error, code: result.error === "EMAIL_NOT_CONFIRMED" ? "EMAIL_NOT_CONFIRMED" : undefined },
+        { status }
       );
     }
 

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -29,6 +29,20 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (!/[A-Z]/.test(password)) {
+      return NextResponse.json(
+        { error: "Password must contain at least one uppercase letter" },
+        { status: 400 }
+      );
+    }
+
+    if (!/\d/.test(password)) {
+      return NextResponse.json(
+        { error: "Password must contain at least one number" },
+        { status: 400 }
+      );
+    }
+
     const result = await signUp(email, password, name);
 
     if (!result.success) {

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -12,11 +12,15 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 function ForgotPasswordContent() {
   const searchParams = useSearchParams();
-  const expiredLink = searchParams.get("error") === "expired";
+  const errorParam = searchParams.get("error");
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(
-    expiredLink ? "Your reset link has expired or is invalid. Please request a new one." : null
+    errorParam === "expired"
+      ? "Your reset link has expired or is invalid. Please request a new one below."
+      : errorParam === "used"
+      ? "This reset link has already been used. If you still need to reset your password, request a new link below."
+      : null
   );
   const [sent, setSent] = useState(false);
 
@@ -108,15 +112,35 @@ function ForgotPasswordContent() {
                 If an account exists for <strong>{email.trim().toLowerCase()}</strong>, you will
                 receive a password reset email shortly.
               </p>
-              <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
-                <p className="text-xs text-amber-700 dark:text-amber-400">
-                  <strong>Tip:</strong> Check your spam/junk folder if you don&apos;t see the email within a few minutes. For @saharacompanies.com addresses, also check your IT-managed email filters.
+              <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3 text-left">
+                <p className="text-xs font-medium text-amber-700 dark:text-amber-400 mb-1">
+                  Don&apos;t see the email?
                 </p>
+                <ul className="text-xs text-amber-700 dark:text-amber-400 space-y-0.5 list-disc list-inside">
+                  <li>Check your spam or junk folder</li>
+                  {email.trim().toLowerCase().endsWith("@saharacompanies.com") && (
+                    <li>Check your IT-managed email filters (common with @saharacompanies.com)</li>
+                  )}
+                  <li>Make sure you used the email address you signed up with</li>
+                  <li>The email may take 1-2 minutes to arrive</li>
+                </ul>
               </div>
               <Button
-                asChild
+                type="button"
                 variant="outline"
-                className="w-full mt-4 border-gray-300 dark:border-gray-700"
+                onClick={() => {
+                  setSent(false);
+                  setError(null);
+                }}
+                className="w-full border-gray-300 dark:border-gray-700"
+              >
+                <Mail className="w-4 h-4 mr-2" />
+                Try again with a different email
+              </Button>
+              <Button
+                asChild
+                variant="ghost"
+                className="w-full text-gray-500 dark:text-gray-400"
               >
                 <Link href="/login">
                   <ArrowLeft className="w-4 h-4 mr-2" />

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -73,6 +73,12 @@ function LoginContent() {
       const data = await response.json();
 
       if (!response.ok) {
+        if (response.status === 429) {
+          throw new Error("Too many login attempts. Please wait a minute before trying again.");
+        }
+        if (data.code === "EMAIL_NOT_CONFIRMED") {
+          throw new Error("EMAIL_NOT_CONFIRMED");
+        }
         throw new Error(data.error || "Failed to sign in");
       }
 
@@ -83,8 +89,9 @@ function LoginContent() {
     } catch (err) {
       console.error("Login error:", err);
       const msg = err instanceof Error ? err.message : "Failed to sign in";
-      // Enhance generic auth errors with helpful guidance
-      if (msg === "Invalid email or password") {
+      if (msg === "EMAIL_NOT_CONFIRMED") {
+        setError("EMAIL_NOT_CONFIRMED");
+      } else if (msg === "Invalid email or password") {
         setError("Invalid email or password. Double-check your credentials or use \"Forgot password?\" below to reset.");
       } else {
         setError(msg);
@@ -114,7 +121,25 @@ function LoginContent() {
           <div className="bg-white dark:bg-gray-900 rounded-2xl p-8 border border-gray-200 dark:border-gray-800 shadow-lg">
             {error && (
               <div role="alert" className="mb-6 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 text-red-600 dark:text-red-400 px-4 py-3 rounded-lg text-sm">
-                {error}
+                {error === "EMAIL_NOT_CONFIRMED" ? (
+                  <div className="space-y-2">
+                    <p className="font-medium">Your email address hasn&apos;t been confirmed yet.</p>
+                    <p>Please check your inbox (and spam/junk folder) for the confirmation email.{" "}
+                      {email.trim().toLowerCase().endsWith("@saharacompanies.com") && (
+                        <>For <strong>@saharacompanies.com</strong> addresses, also check your IT-managed email filters.</>
+                      )}
+                    </p>
+                    <p>
+                      Need a new confirmation?{" "}
+                      <Link href="/forgot-password" className="text-[#ff6a1a] hover:underline font-medium">
+                        Reset your password
+                      </Link>{" "}
+                      to confirm your account and set a new password.
+                    </p>
+                  </div>
+                ) : (
+                  error
+                )}
               </div>
             )}
 

--- a/lib/supabase/auth-helpers.ts
+++ b/lib/supabase/auth-helpers.ts
@@ -137,6 +137,15 @@ export async function supabaseSignIn(
       if (error.message.includes("Invalid login credentials")) {
         return { success: false, error: "Invalid email or password" };
       }
+      if (error.message.includes("Email not confirmed")) {
+        return { success: false, error: "EMAIL_NOT_CONFIRMED" };
+      }
+      if (error.message.includes("rate limit") || error.status === 429) {
+        return { success: false, error: "Too many login attempts. Please wait a few minutes before trying again." };
+      }
+      if (error.message.includes("disabled") || error.message.includes("banned")) {
+        return { success: false, error: "This account has been disabled. Please contact support for assistance." };
+      }
       return { success: false, error: error.message };
     }
 


### PR DESCRIPTION
Closes PERS-235

## Summary
- **Unconfirmed email handling**: Login now detects unconfirmed emails (403 vs 401) and shows a rich error with guidance to check inbox/spam and link to password reset for re-confirmation
- **Rate limit UX**: Rate-limited login attempts show a clear "wait a minute" message instead of a generic error
- **Disabled account handling**: Banned/disabled accounts get a "contact support" message
- **Reset link errors**: Auth callback differentiates expired vs already-used reset links; forgot-password page shows appropriate messages for each
- **Email troubleshooting**: Expanded tips on forgot-password success (spam folder, IT-managed filters for @saharacompanies.com, delivery delay)
- **Try again flow**: Added "Try again with a different email" button on forgot-password success state
- **Password validation alignment**: Signup API now enforces the same rules as reset-password (8+ chars, one uppercase, one number) to prevent users from creating weak passwords they can't use after a reset

## Testing
- All 60 auth tests pass (token + integration)
- TypeScript compiles clean (no new errors)
- Verified no regressions in login, signup, forgot-password, reset-password, and callback routes

Linear: https://linear.app/ai-acrobatics/issue/PERS-235/research-fix-loginpassword-reset-flow-for-sahara-emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)