### PR TITLE
PERS-272: Ensure all FRED evals reference OPERATING-BIBLE.md

### DIFF
--- a/lib/db/__tests__/fred-memory.test.ts
+++ b/lib/db/__tests__/fred-memory.test.ts
@@ -1,5 +1,13 @@
 /**
  * Tests for FRED Memory Access Functions
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * TRACEABILITY: Every eval criterion in this file MUST map to a section
+ * in .planning/OPERATING-BIBLE.md or an existing test in prompts.test.ts.
+ * See .planning/FRED-EVAL-TRACEABILITY.md for the complete mapping.
+ * Do NOT add new criteria without updating the traceability document.
+ * Source of truth: docs/SAHARA-FRED-AUTORESEARCH-WORKFLOW.md (Section 8)
+ * ═══════════════════════════════════════════════════════════════════════
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/lib/fred/__tests__/context-builder.test.ts
+++ b/lib/fred/__tests__/context-builder.test.ts
@@ -6,6 +6,14 @@
  *
  * Phase 79 changed the output format from "FOUNDER SNAPSHOT" (legacy buildContextBlock)
  * to "ACTIVE FOUNDER CONTEXT" (formatMemoryBlock from active-memory.ts).
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * TRACEABILITY: Every eval criterion in this file MUST map to a section
+ * in .planning/OPERATING-BIBLE.md or an existing test in prompts.test.ts.
+ * See .planning/FRED-EVAL-TRACEABILITY.md for the complete mapping.
+ * Do NOT add new criteria without updating the traceability document.
+ * Source of truth: docs/SAHARA-FRED-AUTORESEARCH-WORKFLOW.md (Section 8)
+ * ═══════════════════════════════════════════════════════════════════════
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/lib/fred/__tests__/fred-machine.test.ts
+++ b/lib/fred/__tests__/fred-machine.test.ts
@@ -1,5 +1,13 @@
 /**
  * Tests for FRED State Machine
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * TRACEABILITY: Every eval criterion in this file MUST map to a section
+ * in .planning/OPERATING-BIBLE.md or an existing test in prompts.test.ts.
+ * See .planning/FRED-EVAL-TRACEABILITY.md for the complete mapping.
+ * Do NOT add new criteria without updating the traceability document.
+ * Source of truth: docs/SAHARA-FRED-AUTORESEARCH-WORKFLOW.md (Section 8)
+ * ═══════════════════════════════════════════════════════════════════════
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/lib/fred/__tests__/reality-lens-quick.test.ts
+++ b/lib/fred/__tests__/reality-lens-quick.test.ts
@@ -5,6 +5,14 @@
  *
  * Tests the stage mapping logic with string-based customerValidation
  * and prototypeStage params (matching QuickAnswers field values).
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * TRACEABILITY: Every eval criterion in this file MUST map to a section
+ * in .planning/OPERATING-BIBLE.md or an existing test in prompts.test.ts.
+ * See .planning/FRED-EVAL-TRACEABILITY.md for the complete mapping.
+ * Do NOT add new criteria without updating the traceability document.
+ * Source of truth: docs/SAHARA-FRED-AUTORESEARCH-WORKFLOW.md (Section 8)
+ * ═══════════════════════════════════════════════════════════════════════
  */
 
 import { describe, it, expect } from "vitest"

--- a/lib/fred/__tests__/reality-lens.test.ts
+++ b/lib/fred/__tests__/reality-lens.test.ts
@@ -2,6 +2,14 @@
  * Reality Lens Assessment Engine Tests
  *
  * Tests for the 5-factor Reality Lens assessment system.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * TRACEABILITY: Every eval criterion in this file MUST map to a section
+ * in .planning/OPERATING-BIBLE.md or an existing test in prompts.test.ts.
+ * See .planning/FRED-EVAL-TRACEABILITY.md for the complete mapping.
+ * Do NOT add new criteria without updating the traceability document.
+ * Source of truth: docs/SAHARA-FRED-AUTORESEARCH-WORKFLOW.md (Section 8)
+ * ═══════════════════════════════════════════════════════════════════════
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/lib/fred/scoring/__tests__/scoring.test.ts
+++ b/lib/fred/scoring/__tests__/scoring.test.ts
@@ -1,5 +1,13 @@
 /**
  * Tests for FRED 7-Factor Scoring Engine
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * TRACEABILITY: Every eval criterion in this file MUST map to a section
+ * in .planning/OPERATING-BIBLE.md or an existing test in prompts.test.ts.
+ * See .planning/FRED-EVAL-TRACEABILITY.md for the complete mapping.
+ * Do NOT add new criteria without updating the traceability document.
+ * Source of truth: docs/SAHARA-FRED-AUTORESEARCH-WORKFLOW.md (Section 8)
+ * ═══════════════════════════════════════════════════════════════════════
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";

--- a/lib/hooks/__tests__/use-fred-chat.test.ts
+++ b/lib/hooks/__tests__/use-fred-chat.test.ts
@@ -2,6 +2,14 @@
  * Tests for useFredChat hook
  *
  * Tests the FRED chat integration hook functionality.
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * TRACEABILITY: Every eval criterion in this file MUST map to a section
+ * in .planning/OPERATING-BIBLE.md or an existing test in prompts.test.ts.
+ * See .planning/FRED-EVAL-TRACEABILITY.md for the complete mapping.
+ * Do NOT add new criteria without updating the traceability document.
+ * Source of truth: docs/SAHARA-FRED-AUTORESEARCH-WORKFLOW.md (Section 8)
+ * ═══════════════════════════════════════════════════════════════════════
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";

--- a/tests/fred/memory-management.test.ts
+++ b/tests/fred/memory-management.test.ts
@@ -1,5 +1,13 @@
 /**
  * Tests for Phase 32-02: Memory Management UI & TTS Voice Settings
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * TRACEABILITY: Every eval criterion in this file MUST map to a section
+ * in .planning/OPERATING-BIBLE.md or an existing test in prompts.test.ts.
+ * See .planning/FRED-EVAL-TRACEABILITY.md for the complete mapping.
+ * Do NOT add new criteria without updating the traceability document.
+ * Source of truth: docs/SAHARA-FRED-AUTORESEARCH-WORKFLOW.md (Section 8)
+ * ═══════════════════════════════════════════════════════════════════════
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";

--- a/tests/fred/tts-memory-export.test.ts
+++ b/tests/fred/tts-memory-export.test.ts
@@ -1,5 +1,13 @@
 /**
  * Tests for Phase 32-01: TTS, Memory Browser, Chat Export
+ *
+ * ═══════════════════════════════════════════════════════════════════════
+ * TRACEABILITY: Every eval criterion in this file MUST map to a section
+ * in .planning/OPERATING-BIBLE.md or an existing test in prompts.test.ts.
+ * See .planning/FRED-EVAL-TRACEABILITY.md for the complete mapping.
+ * Do NOT add new criteria without updating the traceability document.
+ * Source of truth: docs/SAHARA-FRED-AUTORESEARCH-WORKFLOW.md (Section 8)
+ * ═══════════════════════════════════════════════════════════════════════
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";


### PR DESCRIPTION
## Summary
- Added OPERATING-BIBLE.md traceability header to 9 FRED eval/test files that were missing it
- All 11 FRED test files now contain the standard traceability block referencing `.planning/OPERATING-BIBLE.md`
- All 260 tests pass across all FRED eval files

## Files updated
- `tests/fred/memory-management.test.ts`
- `tests/fred/tts-memory-export.test.ts`
- `lib/fred/__tests__/fred-machine.test.ts`
- `lib/fred/__tests__/reality-lens.test.ts`
- `lib/fred/__tests__/reality-lens-quick.test.ts`
- `lib/fred/__tests__/context-builder.test.ts`
- `lib/hooks/__tests__/use-fred-chat.test.ts`
- `lib/db/__tests__/fred-memory.test.ts`
- `lib/fred/scoring/__tests__/scoring.test.ts`

## Test plan
- [x] All 260 FRED eval tests pass
- [x] `grep -rL "OPERATING-BIBLE"` returns no FRED test files

Linear: PERS-272

🤖 Generated with [Claude Code](https://claude.com/claude-code)