### PR TITLE
feat(sahara): 7 meeting action items from 3/18 founders call

### DIFF
--- a/app/api/boardy/call/route.ts
+++ b/app/api/boardy/call/route.ts
@@ -1,0 +1,125 @@
+/**
+ * Boardy Call Request API Route
+ * AI-3587: Boardy.ai warm investor introductions ($249 tier)
+ *
+ * POST /api/boardy/call - Request a Boardy AI voice call for founder profiling
+ *
+ * This is the primary handoff: founder provides their phone number,
+ * Boardy calls them and conducts a natural conversation to understand
+ * their startup, goals, and what kind of connections they need.
+ *
+ * Studio tier required.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAuth } from "@/lib/auth";
+import { UserTier } from "@/lib/constants";
+import { getUserTier, createTierErrorResponse } from "@/lib/api/tier-middleware";
+import { getBoardyClient } from "@/lib/boardy/client";
+import { createClient } from "@/lib/supabase/server";
+
+// ============================================================================
+// Request Validation
+// ============================================================================
+
+const callRequestSchema = z.object({
+  phoneNumber: z
+    .string()
+    .min(10, "Phone number must be at least 10 digits")
+    .regex(/^\+?[1-9]\d{6,14}$/, "Invalid phone number format. Include country code (e.g., +14155551234)"),
+  name: z.string().optional(),
+  email: z.string().email().optional(),
+});
+
+// ============================================================================
+// POST /api/boardy/call
+// ============================================================================
+
+export async function POST(request: NextRequest) {
+  try {
+    // 1. Authenticate
+    const userId = await requireAuth();
+
+    // 2. Check Studio tier
+    const userTier = await getUserTier(userId);
+    if (userTier < UserTier.STUDIO) {
+      return createTierErrorResponse({
+        allowed: false,
+        userTier,
+        requiredTier: UserTier.STUDIO,
+        userId,
+      });
+    }
+
+    // 3. Parse and validate body
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { success: false, error: "Invalid JSON body" },
+        { status: 400 }
+      );
+    }
+
+    const parsed = callRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Validation failed",
+          details: parsed.error.flatten().fieldErrors,
+        },
+        { status: 400 }
+      );
+    }
+
+    // 4. Enrich with user profile data
+    const supabase = await createClient();
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("full_name, email")
+      .eq("id", userId)
+      .single();
+
+    const client = getBoardyClient();
+
+    // 5. Check if real API is available
+    if (!client.isLive) {
+      return NextResponse.json({
+        success: false,
+        error: "Boardy calls are coming soon. Currently using AI-generated matches.",
+        isDemo: true,
+      }, { status: 503 });
+    }
+
+    // 6. Request the call
+    const result = await client.requestCall({
+      phoneNumber: parsed.data.phoneNumber,
+      name: parsed.data.name || profile?.full_name || undefined,
+      email: parsed.data.email || profile?.email || undefined,
+    });
+
+    if (!result.success) {
+      return NextResponse.json(
+        { success: false, error: result.message },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: result.message,
+      referenceId: result.referenceId,
+    });
+  } catch (error) {
+    if (error instanceof Response) return error;
+
+    console.error("[Boardy Call] POST error:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to request Boardy call" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/boardy/webhook/route.ts
+++ b/app/api/boardy/webhook/route.ts
@@ -1,0 +1,224 @@
+/**
+ * Boardy Webhook API Route
+ * AI-3587: Boardy.ai warm investor introductions
+ *
+ * POST /api/boardy/webhook - Receive match notifications from Boardy
+ *
+ * Boardy sends webhooks when:
+ * - match.created: A warm intro opportunity is found (double opt-in pending)
+ * - match.accepted: Both parties agreed to connect
+ * - match.declined: One party declined
+ * - intro.completed: Introduction has been made
+ *
+ * Security: Validates webhook signature via BOARDY_WEBHOOK_SECRET.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { createServiceClient } from "@/lib/supabase/server";
+import { createMatch, updateMatchStatus, getMatchById } from "@/lib/db/boardy";
+import type { BoardyWebhookPayload } from "@/lib/boardy/types";
+
+// ============================================================================
+// Webhook Signature Verification
+// ============================================================================
+
+function verifyWebhookSignature(
+  payload: string,
+  signature: string | null,
+  secret: string
+): boolean {
+  if (!signature) return false;
+
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(payload)
+    .digest("hex");
+
+  // Constant-time comparison to prevent timing attacks
+  try {
+    return crypto.timingSafeEqual(
+      Buffer.from(signature),
+      Buffer.from(expected)
+    );
+  } catch {
+    return false;
+  }
+}
+
+// ============================================================================
+// POST /api/boardy/webhook
+// ============================================================================
+
+export async function POST(request: NextRequest) {
+  const webhookSecret = process.env.BOARDY_WEBHOOK_SECRET;
+
+  // Read raw body for signature verification
+  const rawBody = await request.text();
+
+  // Verify signature if secret is configured
+  if (webhookSecret) {
+    const signature = request.headers.get("x-boardy-signature")
+      || request.headers.get("x-webhook-signature");
+
+    if (!verifyWebhookSignature(rawBody, signature, webhookSecret)) {
+      console.error("[Boardy Webhook] Invalid signature");
+      return NextResponse.json(
+        { success: false, error: "Invalid webhook signature" },
+        { status: 401 }
+      );
+    }
+  }
+
+  // Parse payload
+  let payload: BoardyWebhookPayload;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid JSON payload" },
+      { status: 400 }
+    );
+  }
+
+  if (!payload.event || !payload.referenceId) {
+    return NextResponse.json(
+      { success: false, error: "Missing required fields: event, referenceId" },
+      { status: 400 }
+    );
+  }
+
+  const supabase = createServiceClient();
+
+  try {
+    switch (payload.event) {
+      case "match.created": {
+        // Find the user associated with this reference
+        // The referenceId should map to an existing user via boardy_reference_id
+        // or externalUserId from the initial call request
+        const userId = await resolveUserId(supabase, payload);
+        if (!userId) {
+          console.warn(
+            `[Boardy Webhook] Could not resolve user for ref ${payload.referenceId}`
+          );
+          // Still return 200 to prevent Boardy from retrying
+          return NextResponse.json({ success: true, action: "skipped" });
+        }
+
+        if (payload.match) {
+          await createMatch(supabase, {
+            userId,
+            matchType: mapMatchType(payload.match.type),
+            matchName: formatMatchName(payload.match),
+            matchDescription: payload.match.description || "",
+            matchScore: payload.match.score ?? 0.8,
+            status: "suggested",
+            boardyReferenceId: payload.referenceId,
+            metadata: {
+              source: "boardy_webhook",
+              event: payload.event,
+              linkedinUrl: payload.match.linkedinUrl,
+              title: payload.match.title,
+              company: payload.match.company,
+              ...payload.metadata,
+            },
+          });
+        }
+
+        return NextResponse.json({ success: true, action: "match_created" });
+      }
+
+      case "match.accepted": {
+        // Update existing match to "connected" status
+        const match = await findMatchByReference(supabase, payload.referenceId);
+        if (match) {
+          await updateMatchStatus(supabase, match.id, "connected");
+        }
+        return NextResponse.json({ success: true, action: "match_accepted" });
+      }
+
+      case "match.declined": {
+        const match = await findMatchByReference(supabase, payload.referenceId);
+        if (match) {
+          await updateMatchStatus(supabase, match.id, "declined");
+        }
+        return NextResponse.json({ success: true, action: "match_declined" });
+      }
+
+      case "intro.completed": {
+        const match = await findMatchByReference(supabase, payload.referenceId);
+        if (match) {
+          await updateMatchStatus(supabase, match.id, "intro_sent");
+        }
+        return NextResponse.json({ success: true, action: "intro_completed" });
+      }
+
+      default:
+        console.warn(`[Boardy Webhook] Unknown event: ${payload.event}`);
+        return NextResponse.json({ success: true, action: "ignored" });
+    }
+  } catch (error) {
+    console.error("[Boardy Webhook] Processing error:", error);
+    return NextResponse.json(
+      { success: false, error: "Internal processing error" },
+      { status: 500 }
+    );
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async function resolveUserId(
+  supabase: ReturnType<typeof createServiceClient>,
+  payload: BoardyWebhookPayload
+): Promise<string | null> {
+  // Try to find a user who has a match with this boardy_reference_id
+  const { data } = await supabase
+    .from("boardy_matches")
+    .select("user_id")
+    .eq("boardy_reference_id", payload.referenceId)
+    .limit(1)
+    .single();
+
+  if (data?.user_id) return data.user_id;
+
+  // Check metadata for externalUserId
+  if (payload.metadata?.externalUserId) {
+    return payload.metadata.externalUserId as string;
+  }
+
+  return null;
+}
+
+async function findMatchByReference(
+  supabase: ReturnType<typeof createServiceClient>,
+  referenceId: string
+) {
+  const { data } = await supabase
+    .from("boardy_matches")
+    .select("*")
+    .eq("boardy_reference_id", referenceId)
+    .limit(1)
+    .single();
+
+  return data;
+}
+
+function mapMatchType(type: string): "investor" | "advisor" | "mentor" | "partner" {
+  const normalized = type?.toLowerCase() || "";
+  if (normalized.includes("invest") || normalized.includes("vc") || normalized.includes("angel")) {
+    return "investor";
+  }
+  if (normalized.includes("mentor")) return "mentor";
+  if (normalized.includes("partner")) return "partner";
+  return "advisor";
+}
+
+function formatMatchName(match: { name: string; company?: string }): string {
+  if (match.name && match.company) {
+    return `${match.name}, ${match.company}`;
+  }
+  return match.name || "Unknown";
+}

--- a/app/api/documents/quick-score/route.ts
+++ b/app/api/documents/quick-score/route.ts
@@ -1,0 +1,160 @@
+/**
+ * Document Quick Score API (Free Tier)
+ *
+ * POST /api/documents/quick-score
+ * Accepts a PDF upload, extracts text, scores it with AI, and returns
+ * a letter grade (A-F) with a high-level summary report.
+ *
+ * FREE TIER: Does NOT store the document. One-time scoring only.
+ * Designed as the upsell trigger — "Want us to turn this C into an A? Upgrade."
+ *
+ * Rate limited to 1 per day for free tier users.
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { requireAuth } from "@/lib/auth"
+import { getUserTier } from "@/lib/api/tier-middleware"
+import { UserTier } from "@/lib/constants"
+import { checkRateLimit, createRateLimitResponse } from "@/lib/api/rate-limit"
+import { isValidPdf } from "@/lib/documents/pdf-processor"
+import { scoreDeck } from "@/lib/ai/deck-scoring"
+import type { DeckScorecard } from "@/types/deck-review"
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+
+// Free tier: 1 quick score per day. Pro/Studio: 10 per day.
+const QUICK_SCORE_LIMITS: Record<number, { limit: number; windowSeconds: number }> = {
+  [UserTier.FREE]: { limit: 1, windowSeconds: 86400 },
+  [UserTier.PRO]: { limit: 10, windowSeconds: 86400 },
+  [UserTier.STUDIO]: { limit: 50, windowSeconds: 86400 },
+}
+
+/**
+ * Convert a numeric score (1-10) to a letter grade (A through F).
+ */
+function scoreToLetterGrade(score: number): string {
+  if (score >= 9) return "A"
+  if (score >= 8) return "A-"
+  if (score >= 7) return "B+"
+  if (score >= 6.5) return "B"
+  if (score >= 6) return "B-"
+  if (score >= 5.5) return "C+"
+  if (score >= 5) return "C"
+  if (score >= 4.5) return "C-"
+  if (score >= 4) return "D+"
+  if (score >= 3) return "D"
+  return "F"
+}
+
+/**
+ * Build a free-tier summary report from the scorecard.
+ * Gives the grade + high-level feedback but not the detailed fixes (those are for paid).
+ */
+function buildFreeReport(scorecard: DeckScorecard) {
+  const grade = scoreToLetterGrade(scorecard.overallScore)
+
+  const dimensionGrades = scorecard.dimensions.map((d) => ({
+    name: d.name,
+    grade: scoreToLetterGrade(d.score),
+    explanation: d.explanation,
+  }))
+
+  return {
+    grade,
+    overallScore: scorecard.overallScore,
+    summary: scorecard.summary,
+    topStrength: scorecard.topStrength,
+    biggestGap: scorecard.biggestGap,
+    dimensions: dimensionGrades,
+    // Upsell messaging
+    upgradeMessage:
+      grade >= "C"
+        ? `Your document scored a ${grade}. With our Builder plan ($99/mo), I can help you improve each dimension, store your documents, and monitor them as your market evolves. Want to turn this into an A?`
+        : `Your document scored a ${grade} — there's significant room for improvement. With our Builder plan ($99/mo), I'll work with you to systematically strengthen every dimension and track your progress over time.`,
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const userId = await requireAuth()
+    const userTier = await getUserTier(userId)
+
+    // Rate limit
+    const tierConfig = QUICK_SCORE_LIMITS[userTier] ?? QUICK_SCORE_LIMITS[UserTier.FREE]
+    const rateLimitResult = await checkRateLimit(`quick-score:${userId}`, tierConfig)
+    if (!rateLimitResult.success) {
+      return createRateLimitResponse(rateLimitResult)
+    }
+
+    // Parse multipart form data
+    const formData = await request.formData()
+    const file = formData.get("file") as File | null
+
+    if (!file) {
+      return NextResponse.json({ error: "No file provided" }, { status: 400 })
+    }
+
+    // Validate PDF
+    if (file.type !== "application/pdf") {
+      return NextResponse.json({ error: "Only PDF files are accepted" }, { status: 400 })
+    }
+
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        { error: `File size exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit` },
+        { status: 400 }
+      )
+    }
+
+    const arrayBuffer = await file.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+
+    if (!isValidPdf(buffer)) {
+      return NextResponse.json({ error: "Invalid PDF file" }, { status: 400 })
+    }
+
+    // Extract text from PDF (using dynamic import to avoid bundling issues)
+    let textContent: string
+    try {
+      const pdfParse = (await import("pdf-parse")).default
+      const pdfData = await pdfParse(buffer)
+      textContent = pdfData.text
+    } catch {
+      return NextResponse.json(
+        { error: "Failed to extract text from PDF. The file may be image-based or corrupted." },
+        { status: 422 }
+      )
+    }
+
+    if (!textContent || textContent.trim().length < 50) {
+      return NextResponse.json(
+        { error: "Could not extract enough text from the PDF. It may be image-based — try a text-based PDF." },
+        { status: 422 }
+      )
+    }
+
+    // Score with AI — same scoring engine, but we only return the summary to free users
+    const scorecard = await scoreDeck(textContent.substring(0, 15000))
+
+    // Build free-tier report (grade + summary, no detailed fix suggestions)
+    const report = buildFreeReport(scorecard)
+
+    // NOTE: We do NOT store the document for free tier users.
+    // The scoring result is returned but not persisted.
+
+    return NextResponse.json({
+      success: true,
+      report,
+      // Include tier info for frontend upsell UI
+      userTier: userTier === UserTier.FREE ? "free" : "paid",
+      canStoreDocuments: userTier >= UserTier.PRO,
+    })
+  } catch (error) {
+    if (error instanceof Response) return error
+    console.error("[QuickScore] Error:", error)
+    return NextResponse.json(
+      { error: "Failed to score document" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/fred/call/transcript/route.ts
+++ b/app/api/fred/call/transcript/route.ts
@@ -56,13 +56,25 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    await injectVoiceTranscriptToChat(
+    const result = await injectVoiceTranscriptToChat(
       userId,
       body.roomName,
       body.transcript as VoiceTranscriptEntry[]
     )
 
-    return NextResponse.json({ success: true })
+    if (result.error && !result.stored) {
+      console.error("[Fred Call Transcript] Storage failed completely:", result.error)
+      return NextResponse.json(
+        { success: false, error: "Failed to store transcript", entriesStored: 0 },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      entriesStored: result.entriesStored,
+      ...(result.error ? { warning: "Some entries may not have been stored" } : {}),
+    })
   } catch (error) {
     // requireAuth throws NextResponse on 401
     if (error instanceof NextResponse) return error

--- a/app/api/fred/chat/route.ts
+++ b/app/api/fred/chat/route.ts
@@ -434,16 +434,18 @@ async function handlePost(req: NextRequest) {
       serverTrack(userId, ANALYTICS_EVENTS.CHAT.SESSION_STARTED, { tier: tierName });
     }
 
-    // Phase 21: Only persist memory for Pro+ tiers; Free tier is session-only.
-    // INTENTIONAL DESIGN: Free-tier users do NOT get entries in fred_episodic_memory.
-    // Their conversations are not stored across sessions — this is a core product
-    // differentiator between Free and Pro tiers. Free users still benefit from
-    // session-scoped context (within a single request) via loadMemoryActor, but
-    // nothing is written to the DB. For re-engagement tracking, all tiers DO get
-    // journey_events rows (see the fire-and-forget insert near the "done" SSE event
-    // below) so email campaigns have activity data without exposing conversation content.
-    // To change this behaviour, update hasPersistentMemory above.
-    const shouldPersistMemory = storeInMemory && hasPersistentMemory;
+    // Phase 21 (Updated per Sahara Founders Meeting 2026-03-18):
+    // ALL conversations are now stored regardless of tier. This serves:
+    // 1. Valuation: User/conversation count matters for company valuation
+    // 2. Re-engagement: Past conversations enable smarter follow-up
+    // 3. Learning: All conversation data improves the AI over time
+    //
+    // The tier gate is on LOADING, not STORING:
+    // - Free tier: Conversations stored but NOT loaded as context in future sessions
+    // - Pro+: Full persistent memory with context loading
+    //
+    // hasPersistentMemory still controls whether FRED loads past context.
+    const shouldPersistMemory = storeInMemory; // Always store, regardless of tier
 
     // ── Parallel context loading ─────────────────────────────────────
     // Fetch conversation state first (single fast query) so it can be
@@ -1154,16 +1156,26 @@ INSTRUCTIONS: When natural in conversation, check in on these. Ask "How did X go
             });
 
             // Store assistant response in memory (Pro+ only, Phase 21)
+            // Retry up to 2 times on failure — this is the only record of the response
             if (shouldPersistMemory) {
-              try {
-                await storeEpisode(userId, effectiveSessionId, "conversation", {
-                  role: "assistant",
-                  content: response.content,
-                  action: response.action,
-                  confidence: response.confidence,
-                });
-              } catch (error) {
-                console.warn("[FRED Chat] Failed to store assistant response:", error);
+              const maxRetries = 2;
+              for (let attempt = 0; attempt <= maxRetries; attempt++) {
+                try {
+                  await storeEpisode(userId, effectiveSessionId, "conversation", {
+                    role: "assistant",
+                    content: response.content,
+                    action: response.action,
+                    confidence: response.confidence,
+                  });
+                  break; // Success — exit retry loop
+                } catch (error) {
+                  if (attempt < maxRetries) {
+                    console.warn(`[FRED Chat] Failed to store assistant response (attempt ${attempt + 1}/${maxRetries + 1}), retrying:`, error);
+                    await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+                  } else {
+                    console.error("[FRED Chat] Failed to store assistant response after all retries:", error);
+                  }
+                }
               }
             }
 

--- a/app/api/fred/chat/route.ts
+++ b/app/api/fred/chat/route.ts
@@ -35,7 +35,7 @@ import { buildFounderContextWithFacts } from "@/lib/fred/context-builder";
 import { extractMemoryUpdates, persistMemoryUpdates } from "@/lib/fred/active-memory";
 import { getOrCreateConversationState, getRealityLensGate, checkGateStatus, incrementGateRedirect, getActiveMode, updateActiveMode, markIntroductionDelivered, updateStageRedirectCounts } from "@/lib/db/conversation-state";
 import type { ConversationState } from "@/lib/db/conversation-state";
-import { buildStepGuidanceBlock, buildRealityLensGateBlock, buildRealityLensStatusBlock, buildFrameworkInjectionBlock, buildModeTransitionBlock, buildIRSPromptBlock, buildDeckProtocolBlock, buildDeckReviewReadyBlock } from "@/lib/ai/prompts";
+import { buildStepGuidanceBlock, buildRealityLensGateBlock, buildRealityLensStatusBlock, buildFrameworkInjectionBlock, buildModeTransitionBlock, buildIRSPromptBlock, buildDeckProtocolBlock, buildDeckReviewReadyBlock, buildMissingFundamentalsBlock } from "@/lib/ai/prompts";
 import { determineModeTransition, type DiagnosticMode } from "@/lib/ai/diagnostic-engine";
 import type { ConversationStateContext } from "@/lib/fred/types";
 import { estimateTokens } from "@/lib/ai/context-manager";

--- a/app/api/fred/chat/route.ts
+++ b/app/api/fred/chat/route.ts
@@ -53,6 +53,7 @@ import { validateStageAccess } from "@/lib/oases/stage-validator";
 import { buildStageAwarePromptBlock, buildStageRedirectBlock } from "@/lib/oases/stage-gate-prompt";
 import type { OasesStage } from "@/types/oases";
 import { createAuditEntry, updateAuditSentiment } from "@/lib/audit/fred-audit";
+import { detectUpsellTrigger, getUpsellMessage } from "@/lib/chat/upsell-detector";
 
 export const maxDuration = 60; // Allow up to 60s for FRED's AI pipeline on Vercel Pro
 
@@ -1023,6 +1024,31 @@ INSTRUCTIONS: When natural in conversation, check in on these. Ask "How did X go
           timestamp: new Date().toISOString(),
           tier: tierName,
         });
+
+        // ── Upsell Detection (Free tier only) ───────────────────────────
+        // Detect if the free-tier user is asking for a Pro feature (doc review,
+        // pitch deck improvement, document storage, strategy docs, etc.)
+        // and emit an upsell SSE event so the client can show an inline prompt.
+        if (userTier === UserTier.FREE) {
+          const upsellDetection = detectUpsellTrigger(message);
+          if (upsellDetection.detected && upsellDetection.trigger) {
+            send("upsell", {
+              trigger: upsellDetection.trigger,
+              confidence: upsellDetection.confidence,
+              featureLabel: upsellDetection.featureLabel,
+              mentorMessage: getUpsellMessage(upsellDetection.trigger),
+            });
+
+            // Track upsell impression (fire-and-forget)
+            serverTrack(userId, "upsell.prompt_shown", {
+              trigger: upsellDetection.trigger,
+              featureLabel: upsellDetection.featureLabel,
+              confidence: upsellDetection.confidence,
+              tier: tierName,
+              source: "chat_inline",
+            });
+          }
+        }
 
         // Store user message in memory (Pro+ only, Phase 21)
         // Fire-and-forget: don't block processStream start on this DB write

--- a/components/admin/voice-agent/AgentConfigForm.tsx
+++ b/components/admin/voice-agent/AgentConfigForm.tsx
@@ -144,7 +144,7 @@ export function AgentConfigForm({ config, onSave }: AgentConfigFormProps) {
               id="system_prompt"
               value={formData.system_prompt}
               onChange={(e) => handleChange('system_prompt', e.target.value)}
-              placeholder="You are a helpful AI assistant..."
+              placeholder="You are a startup mentor guiding founders..."
               rows={8}
               className="font-mono text-sm"
             />

--- a/components/chat/chat-message.tsx
+++ b/components/chat/chat-message.tsx
@@ -204,6 +204,10 @@ export function ChatMessage({
                   ))}
                 </div>
               )}
+              {/* Inline upsell prompt for free-tier users */}
+              {message.upsellPrompt && !message.isStreaming && (
+                <UpsellPromptCard upsell={message.upsellPrompt} />
+              )}
             </div>
           )}
         </motion.div>

--- a/components/chat/chat-message.tsx
+++ b/components/chat/chat-message.tsx
@@ -11,6 +11,8 @@ import { TtsButton } from "./tts-button";
 import ReactMarkdown from "react-markdown";
 import { CourseCardInline } from "@/components/content/course-card-inline";
 import { ProviderCardInline } from "@/components/marketplace/provider-card-inline";
+import { UpsellPromptCard } from "./upsell-prompt";
+import type { UpsellPrompt } from "@/lib/hooks/use-fred-chat";
 
 /**
  * Strip orphaned/unclosed markdown tokens during streaming to prevent
@@ -53,6 +55,8 @@ export interface Message {
     review_count: number;
     is_verified?: boolean;
   }>;
+  /** In-chat upsell prompt for free-tier users */
+  upsellPrompt?: UpsellPrompt;
 }
 
 interface ChatMessageProps {

--- a/components/chat/upsell-prompt.tsx
+++ b/components/chat/upsell-prompt.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { useState } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import { Sparkles, ArrowRight, X } from "lucide-react"
+import { redirectToCheckoutByTier } from "@/lib/stripe/client"
+import { trackEvent } from "@/lib/analytics"
+import { ANALYTICS_EVENTS } from "@/lib/analytics/events"
+import { cn } from "@/lib/utils"
+import type { UpsellPrompt as UpsellPromptType } from "@/lib/hooks/use-fred-chat"
+
+interface UpsellPromptProps {
+  upsell: UpsellPromptType
+}
+
+export function UpsellPromptCard({ upsell }: UpsellPromptProps) {
+  const [dismissed, setDismissed] = useState(false)
+  const [isRedirecting, setIsRedirecting] = useState(false)
+
+  const handleUpgrade = async () => {
+    setIsRedirecting(true)
+    trackEvent(ANALYTICS_EVENTS.UPSELL.CTA_CLICKED, {
+      trigger: upsell.trigger,
+      featureLabel: upsell.featureLabel,
+      source: "chat_inline",
+    })
+    trackEvent(ANALYTICS_EVENTS.SUBSCRIPTION.CHECKOUT_STARTED, {
+      fromTier: "free",
+      toTier: "pro",
+    })
+
+    try {
+      await redirectToCheckoutByTier("PRO")
+    } catch (error) {
+      console.error("[Upsell] Checkout redirect failed:", error)
+      setIsRedirecting(false)
+    }
+  }
+
+  const handleDismiss = () => {
+    setDismissed(true)
+    trackEvent(ANALYTICS_EVENTS.UPSELL.DISMISSED, {
+      trigger: upsell.trigger,
+      featureLabel: upsell.featureLabel,
+      source: "chat_inline",
+    })
+  }
+
+  return (
+    <AnimatePresence>
+      {!dismissed && (
+        <motion.div
+          initial={{ opacity: 0, y: 8, scale: 0.97 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={{ opacity: 0, y: -4, scale: 0.97 }}
+          transition={{ duration: 0.3, ease: "easeOut" }}
+          className="mt-3 not-prose"
+        >
+          <div
+            className={cn(
+              "relative rounded-xl overflow-hidden",
+              "border border-[#ff6a1a]/30",
+              "bg-gradient-to-br from-[#ff6a1a]/5 via-orange-500/5 to-amber-500/5",
+              "backdrop-blur-sm"
+            )}
+          >
+            {/* Dismiss button */}
+            <button
+              onClick={handleDismiss}
+              className={cn(
+                "absolute top-2.5 right-2.5 z-10",
+                "p-1 rounded-full",
+                "text-foreground/40 hover:text-foreground/70",
+                "hover:bg-white/10",
+                "transition-colors duration-200"
+              )}
+              aria-label="Dismiss upgrade prompt"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+
+            <div className="p-4">
+              {/* Header with sparkle icon */}
+              <div className="flex items-center gap-2 mb-2">
+                <div className="flex items-center justify-center h-6 w-6 rounded-full bg-[#ff6a1a]/15">
+                  <Sparkles className="h-3.5 w-3.5 text-[#ff6a1a]" />
+                </div>
+                <span className="text-xs font-semibold text-[#ff6a1a] uppercase tracking-wider">
+                  Unlock Pro
+                </span>
+              </div>
+
+              {/* Feature label */}
+              <p className="text-sm font-medium text-foreground/90 mb-2">
+                {upsell.featureLabel}
+              </p>
+
+              {/* Pro tier highlights */}
+              <div className="grid grid-cols-2 gap-1 mb-3">
+                {[
+                  "Pitch Deck Review",
+                  "Strategy Docs",
+                  "Investor Readiness",
+                  "30-Day Memory",
+                ].map((feature) => (
+                  <div
+                    key={feature}
+                    className="flex items-center gap-1.5 text-xs text-foreground/60"
+                  >
+                    <div className="h-1 w-1 rounded-full bg-[#ff6a1a]/60 flex-shrink-0" />
+                    {feature}
+                  </div>
+                ))}
+              </div>
+
+              {/* CTA Button */}
+              <button
+                onClick={handleUpgrade}
+                disabled={isRedirecting}
+                className={cn(
+                  "w-full flex items-center justify-center gap-2",
+                  "px-4 py-2.5 rounded-lg",
+                  "text-sm font-medium text-white",
+                  "bg-[#ff6a1a] hover:bg-[#ea580c]",
+                  "shadow-lg shadow-[#ff6a1a]/25 hover:shadow-[#ff6a1a]/40",
+                  "transition-all duration-200",
+                  "disabled:opacity-60 disabled:cursor-not-allowed"
+                )}
+              >
+                {isRedirecting ? (
+                  <>
+                    <div className="h-4 w-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    Redirecting...
+                  </>
+                ) : (
+                  <>
+                    Upgrade to Pro — $99/mo
+                    <ArrowRight className="h-4 w-4" />
+                  </>
+                )}
+              </button>
+
+              {/* Subtle reassurance */}
+              <p className="text-[10px] text-foreground/40 text-center mt-2">
+                Cancel anytime · 14-day trial available
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/funnel/src/App.tsx
+++ b/funnel/src/App.tsx
@@ -6,6 +6,7 @@ import { LandingPage } from '@/pages/LandingPage'
 import { ChatPage } from '@/pages/ChatPage'
 import { JourneyPage } from '@/pages/JourneyPage'
 import { FaqPage } from '@/pages/FaqPage'
+import { startPeriodicSync, stopPeriodicSync } from '@/lib/sync-service'
 
 const TAB_STORAGE_KEY = 'sahara-funnel-tab'
 
@@ -21,6 +22,12 @@ export default function App() {
   useEffect(() => {
     sessionStorage.setItem(TAB_STORAGE_KEY, activeTab)
   }, [activeTab])
+
+  // Start periodic data sync to platform API
+  useEffect(() => {
+    startPeriodicSync()
+    return () => stopPeriodicSync()
+  }, [])
 
   const goToChat = useCallback(() => setActiveTab('chat'), [])
 

--- a/funnel/src/pages/ChatPage.tsx
+++ b/funnel/src/pages/ChatPage.tsx
@@ -9,6 +9,7 @@ import {
   loadChatHistory,
   saveChatHistory,
 } from '@/lib/chat-service'
+import { scheduleFunnelSync } from '@/lib/sync-service'
 
 const SUGGESTION_CHIPS = [
   "I have a startup idea",
@@ -40,10 +41,11 @@ export function ChatPage() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages, isLoading])
 
-  // Save to localStorage whenever messages change
+  // Save to localStorage and trigger sync whenever messages change
   useEffect(() => {
     if (messages.length > 1) {
       saveChatHistory(messages)
+      scheduleFunnelSync()
     }
   }, [messages])
 

--- a/funnel/src/pages/JourneyPage.tsx
+++ b/funnel/src/pages/JourneyPage.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { Check, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { JOURNEY_STAGES, BRAND } from '@/lib/constants'
+import { scheduleFunnelSync } from '@/lib/sync-service'
 
 const STORAGE_KEY = 'sahara-funnel-journey'
 
@@ -27,6 +28,7 @@ export function JourneyPage() {
     const newProgress = { ...progress, [key]: !progress[key] }
     setProgress(newProgress)
     saveProgress(newProgress)
+    scheduleFunnelSync()
   }
 
   const getStageProgress = (stageId: string, total: number) => {

--- a/funnel/src/pages/LandingPage.tsx
+++ b/funnel/src/pages/LandingPage.tsx
@@ -150,7 +150,7 @@ export function LandingPage({ onStartChat }: LandingPageProps) {
             transition={{ duration: 0.4, delay: 0.2 }}
             className="text-base text-gray-600 mb-6 leading-relaxed"
           >
-            Fred Cary has coached 10,000+ founders and helped raise over $100M. Now his
+            Fred Cary has coached hundreds of founders and helped raise billions. Now his
             experience is available 24/7 as your AI co-founder.
           </motion.p>
 
@@ -188,11 +188,11 @@ export function LandingPage({ onStartChat }: LandingPageProps) {
           >
             <span className="flex items-center gap-1.5">
               <Users className="w-3.5 h-3.5 text-[#ff6a1a]" />
-              10,000+ Founders
+              Hundreds of Founders
             </span>
             <span className="flex items-center gap-1.5">
               <Sparkles className="w-3.5 h-3.5 text-[#ff6a1a]" />
-              $100M+ Raised
+              Billions Raised
             </span>
             <span className="flex items-center gap-1.5">
               <Shield className="w-3.5 h-3.5 text-[#ff6a1a]" />

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -181,6 +181,93 @@ export function getFredGreeting(startupContext?: {
 }
 
 // ============================================================================
+// Business Fundamentals Enforcement Block
+// ============================================================================
+
+/**
+ * Build an enforcement block for the 7 core business fundamentals.
+ * Adjusts FRED's behavior based on how many fundamentals are still unknown:
+ * - 5+ missing → INTAKE MODE: prioritize collection over advice
+ * - 3-4 missing → BALANCED: collect 2-3 while helping
+ * - 1-2 missing → LIGHT: weave in naturally
+ * - 0 missing → no block
+ *
+ * This overrides the soft "Missing Context" instructions in formatMemoryBlock
+ * with a more directive protocol that prevents vague, generic responses.
+ */
+export function buildMissingFundamentalsBlock(
+  missingFields: string[]
+): string {
+  if (missingFields.length === 0) return "";
+
+  // Map internal field keys to human-readable names for the prompt
+  const fieldLabels: Record<string, string> = {
+    founder_name: "founder's name",
+    company_name: "business/company name",
+    stage: "startup stage (idea, pre-seed, seed, etc.)",
+    market: "industry/sector",
+    co_founder: "co-founder status",
+    revenue_status: "revenue status",
+    team_size: "team size",
+    biggest_challenge: "biggest current challenge",
+    funding_status: "funding status",
+    product_status: "product status",
+    traction: "traction metrics",
+    ninety_day_goal: "90-day goal",
+    key_decisions: "key pending decisions",
+  };
+
+  // The 7 core business fundamentals that must be collected before deep advice
+  const CORE_FUNDAMENTALS = [
+    "company_name", "market", "stage", "revenue_status",
+    "team_size", "funding_status", "co_founder",
+  ];
+
+  const missingCore = missingFields.filter(f => CORE_FUNDAMENTALS.includes(f));
+  const missingLabels = missingFields
+    .slice(0, 10) // Limit labels to avoid prompt bloat
+    .map(f => fieldLabels[f] || f.replace(/_/g, " "))
+    .join(", ");
+
+  if (missingCore.length >= 5) {
+    // INTAKE MODE — most fundamentals unknown
+    return `## BUSINESS FUNDAMENTALS — INTAKE MODE
+
+**MANDATORY:** You are missing ${missingCore.length} of 7 core business fundamentals: ${missingLabels}.
+
+Without these, ANY advice you give will be generic and low-value. Follow this protocol:
+
+1. **Acknowledge their question** with a brief, high-level response (2-3 sentences max)
+2. **Immediately ask for 2-3 of the most relevant missing fundamentals** for their question
+3. **Frame it as personalization:** "To give you advice that actually fits your situation, I need to understand a few things..."
+4. **After each response, check:** "What do I still not know?" — keep asking until you have at least 5 of 7 fundamentals
+
+DO NOT give detailed strategic advice, frameworks, or action plans until you have at least 5 of 7 core fundamentals. Brief directional guidance is OK, but save the deep work for when you know their context.
+
+EXCEPTION: If they're in crisis or urgent mode, help first, then circle back to collect fundamentals.`;
+  }
+
+  if (missingCore.length >= 3) {
+    // BALANCED — some fundamentals known
+    return `## BUSINESS FUNDAMENTALS — COLLECTION NEEDED
+
+You're still missing ${missingCore.length} core fundamentals: ${missingLabels}.
+
+PROTOCOL:
+- Give a helpful response to their question, but **personalize it with what you DO know**
+- In every response, naturally ask about **2 of the missing fundamentals** that are most relevant to the topic
+- Frame it naturally: "Quick question — are you [solo/with a co-founder]?" or "What's your revenue looking like right now?"
+- Once you have 5+ fundamentals, shift to full personalized advice mode`;
+  }
+
+  // LIGHT — almost complete
+  return `## BUSINESS FUNDAMENTALS — ALMOST COMPLETE
+
+You're only missing: ${missingLabels}.
+When naturally relevant, ask about ${missingCore.length === 1 ? "this" : "these"} to complete the founder profile. No need to force it — just weave it in when the topic is related.`;
+}
+
+// ============================================================================
 // Step Guidance Block (Phase 36)
 // ============================================================================
 

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -48,6 +48,16 @@ export const ANALYTICS_EVENTS = {
     CHECKOUT_COMPLETED: "subscription.checkout_completed",
   },
 
+  /** In-chat upsell events */
+  UPSELL: {
+    /** Upsell prompt was shown inline in chat */
+    PROMPT_SHOWN: "upsell.prompt_shown",
+    /** User clicked the upgrade CTA in the upsell prompt */
+    CTA_CLICKED: "upsell.cta_clicked",
+    /** User dismissed the upsell prompt */
+    DISMISSED: "upsell.dismissed",
+  },
+
   /** General engagement events */
   ENGAGEMENT: {
     DASHBOARD_VIEWED: "engagement.dashboard_viewed",
@@ -96,6 +106,13 @@ export interface SubscriptionEventProperties {
   currency?: string;
 }
 
+export interface UpsellEventProperties {
+  trigger?: string;
+  featureLabel?: string;
+  tier?: string;
+  source?: "chat_inline" | "chat_modal";
+}
+
 export interface EngagementEventProperties {
   page?: string;
   section?: string;
@@ -116,4 +133,5 @@ export type AnalyticsEventName =
   | EventValues<EventCategory["CHAT"]>
   | EventValues<EventCategory["FEATURES"]>
   | EventValues<EventCategory["SUBSCRIPTION"]>
+  | EventValues<EventCategory["UPSELL"]>
   | EventValues<EventCategory["ENGAGEMENT"]>;

--- a/lib/boardy/client.ts
+++ b/lib/boardy/client.ts
@@ -1,14 +1,19 @@
 /**
  * Boardy Client - Abstraction Layer (Strategy Pattern)
- * Phase 04: Studio Tier Features - Plan 06
+ * AI-3587: Boardy.ai warm investor introductions ($249 tier)
  *
- * Delegates to an underlying implementation (MockBoardyClient or future real API client).
- * Callers use getBoardyClient() factory and never need to know which implementation is active.
+ * Delegates to an underlying implementation:
+ * - RealBoardyClient: when BOARDY_API_KEY is set (real Boardy API)
+ * - MockBoardyClient: fallback with AI-generated match suggestions
+ *
+ * Callers use getBoardyClient() factory and never need to know which is active.
  */
 
 import type {
   BoardyClientInterface,
   BoardyMatch,
+  BoardyCallRequest,
+  BoardyCallResponse,
   MatchRequest,
 } from "./types";
 import { MockBoardyClient } from "./mock";
@@ -29,6 +34,10 @@ export class BoardyClient implements BoardyClientInterface {
     this.implementation = implementation;
   }
 
+  get isLive(): boolean {
+    return this.implementation.isLive;
+  }
+
   async getMatches(request: MatchRequest): Promise<BoardyMatch[]> {
     return this.implementation.getMatches(request);
   }
@@ -39,6 +48,16 @@ export class BoardyClient implements BoardyClientInterface {
 
   getDeepLink(userId: string): string {
     return this.implementation.getDeepLink(userId);
+  }
+
+  async requestCall(request: BoardyCallRequest): Promise<BoardyCallResponse> {
+    if (this.implementation.requestCall) {
+      return this.implementation.requestCall(request);
+    }
+    return {
+      success: false,
+      message: "Boardy calls are not available in demo mode.",
+    };
   }
 }
 
@@ -52,16 +71,25 @@ let _client: BoardyClient | null = null;
 /**
  * Get the Boardy client singleton.
  *
- * If BOARDY_API_KEY is set, will use the real API client (future).
+ * If BOARDY_API_KEY is set, uses the real Boardy API client.
  * Otherwise falls back to MockBoardyClient which uses AI to generate
  * contextual match suggestions.
  */
 export function getBoardyClient(): BoardyClient {
   if (!_client) {
-    // Future: if (process.env.BOARDY_API_KEY) { _client = new BoardyClient(new RealBoardyClient()); }
-    const implementation = new MockBoardyClient();
-    _client = new BoardyClient(implementation);
-    logger.log("[Boardy] Initialized with MockBoardyClient (AI-generated matches)");
+    const apiKey = process.env.BOARDY_API_KEY;
+
+    if (apiKey) {
+      // Lazy import to avoid loading real client code when not needed
+      const { RealBoardyClient } = require("./real-client");
+      const implementation = new RealBoardyClient(apiKey);
+      _client = new BoardyClient(implementation);
+      logger.log("[Boardy] Initialized with RealBoardyClient (live API)");
+    } else {
+      const implementation = new MockBoardyClient();
+      _client = new BoardyClient(implementation);
+      logger.log("[Boardy] Initialized with MockBoardyClient (AI-generated matches)");
+    }
   }
   return _client;
 }

--- a/lib/boardy/mock.ts
+++ b/lib/boardy/mock.ts
@@ -46,6 +46,8 @@ type MatchSuggestion = z.infer<typeof matchSuggestionSchema>;
 // ============================================================================
 
 export class MockBoardyClient implements BoardyClientInterface {
+  readonly isLive = false;
+
   /**
    * Generate match suggestions using AI and store them in the database.
    */

--- a/lib/boardy/real-client.ts
+++ b/lib/boardy/real-client.ts
@@ -1,0 +1,240 @@
+/**
+ * Real Boardy Client - API Integration
+ * AI-3587: Boardy.ai warm investor introductions ($249 tier)
+ *
+ * Connects to the Boardy API for real investor/advisor matching.
+ * Activated when BOARDY_API_KEY is set. Falls back to MockBoardyClient otherwise.
+ *
+ * Boardy flow:
+ * 1. Founder requests a Boardy call → Boardy AI profiles them via voice
+ * 2. Boardy matches founder with investors/advisors in their network
+ * 3. Double opt-in: both parties must agree before intro is made
+ * 4. Boardy sends webhook → we create match records
+ * 5. Founder prepares for intro using Sahara's prep tools
+ */
+
+import { logger } from "@/lib/logger";
+import {
+  createMatch,
+  getMatches as dbGetMatches,
+  deleteMatchesByStatus,
+} from "@/lib/db/boardy";
+import { createServiceClient } from "@/lib/supabase/server";
+import type {
+  BoardyClientInterface,
+  BoardyMatch,
+  BoardyCallRequest,
+  BoardyCallResponse,
+  MatchRequest,
+} from "./types";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const BOARDY_API_BASE = "https://api.boardy.ai";
+const BOARDY_PARTNER_SLUG = "sahara";
+const REQUEST_TIMEOUT_MS = 15_000;
+
+// ============================================================================
+// Real Client Implementation
+// ============================================================================
+
+export class RealBoardyClient implements BoardyClientInterface {
+  private apiKey: string;
+  readonly isLive = true;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  /**
+   * Get matches from the database.
+   * Real matches come in via webhooks — this just reads what's stored.
+   * If no matches exist, we trigger AI-generated suggestions as a fallback
+   * while the founder waits for real Boardy matches.
+   */
+  async getMatches(request: MatchRequest): Promise<BoardyMatch[]> {
+    const supabase = createServiceClient();
+    const existing = await dbGetMatches(supabase, request.userId, {
+      limit: request.limit ?? 10,
+    });
+
+    if (existing.length > 0) {
+      return existing;
+    }
+
+    // No real matches yet — generate AI suggestions as interim results
+    // This gives founders something useful while they wait for Boardy profiling
+    logger.log(
+      `[RealBoardy] No matches for ${request.userId}, falling back to AI suggestions`
+    );
+    return this.generateFallbackMatches(request);
+  }
+
+  /**
+   * Refresh: fetch latest matches from Boardy API + clear stale suggestions.
+   */
+  async refreshMatches(userId: string): Promise<BoardyMatch[]> {
+    const supabase = createServiceClient();
+
+    // Try to fetch real matches from Boardy
+    try {
+      const response = await this.apiFetch("/v1/matches", {
+        method: "POST",
+        body: JSON.stringify({
+          partnerId: BOARDY_PARTNER_SLUG,
+          externalUserId: userId,
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        if (data.matches && Array.isArray(data.matches)) {
+          // Clear old AI-generated suggestions
+          await deleteMatchesByStatus(supabase, userId, "suggested");
+
+          // Store real matches
+          const stored: BoardyMatch[] = [];
+          for (const m of data.matches) {
+            const match = await createMatch(supabase, {
+              userId,
+              matchType: this.mapMatchType(m.type),
+              matchName: this.formatMatchName(m),
+              matchDescription: m.description || m.bio || "",
+              matchScore: m.score ?? 0.75,
+              status: "suggested",
+              boardyReferenceId: m.referenceId || m.id,
+              metadata: {
+                source: "boardy_api",
+                linkedinUrl: m.linkedinUrl,
+                company: m.company,
+                title: m.title,
+                ...m.metadata,
+              },
+            });
+            stored.push(match);
+          }
+
+          logger.log(
+            `[RealBoardy] Stored ${stored.length} real matches for ${userId}`
+          );
+          return stored;
+        }
+      }
+    } catch (err) {
+      logger.log(
+        `[RealBoardy] API fetch failed, falling back to AI suggestions: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    // Fallback: delete old suggestions and generate new AI ones
+    await deleteMatchesByStatus(supabase, userId, "suggested");
+    return this.generateFallbackMatches({
+      userId,
+      startupStage: "seed",
+      sector: "technology",
+      matchTypes: ["investor", "advisor"],
+      limit: 5,
+    });
+  }
+
+  /**
+   * Request a Boardy AI voice call for founder profiling.
+   * This is the primary handoff point: founder provides phone number,
+   * Boardy calls them, conducts a natural conversation, and builds their profile.
+   */
+  async requestCall(request: BoardyCallRequest): Promise<BoardyCallResponse> {
+    try {
+      const response = await this.apiFetch("/user/upsert-and-call-public", {
+        method: "POST",
+        body: JSON.stringify({
+          phoneNumber: request.phoneNumber,
+          name: request.name,
+          email: request.email,
+          slug: request.slug || BOARDY_PARTNER_SLUG,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "Unknown error");
+        logger.log(`[RealBoardy] Call request failed: ${response.status} ${errorText}`);
+        return {
+          success: false,
+          message: `Boardy call request failed (${response.status})`,
+        };
+      }
+
+      const data = await response.json().catch(() => ({}));
+      logger.log(`[RealBoardy] Call requested for ${request.name || "unknown"}`);
+
+      return {
+        success: true,
+        message: "Boardy will call you shortly to learn about your startup.",
+        referenceId: data.referenceId || data.id,
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.log(`[RealBoardy] Call request error: ${msg}`);
+      return {
+        success: false,
+        message: "Failed to request Boardy call. Please try again.",
+      };
+    }
+  }
+
+  getDeepLink(userId: string): string {
+    return `https://www.boardy.ai/?ref=${BOARDY_PARTNER_SLUG}&uid=${userId}`;
+  }
+
+  // ============================================================================
+  // Private Helpers
+  // ============================================================================
+
+  private async apiFetch(path: string, init?: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      return await fetch(`${BOARDY_API_BASE}${path}`, {
+        ...init,
+        signal: controller.signal,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.apiKey}`,
+          "X-Partner": BOARDY_PARTNER_SLUG,
+          ...(init?.headers || {}),
+        },
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private mapMatchType(type: string): "investor" | "advisor" | "mentor" | "partner" {
+    const normalized = type?.toLowerCase() || "";
+    if (normalized.includes("invest") || normalized.includes("vc") || normalized.includes("angel")) {
+      return "investor";
+    }
+    if (normalized.includes("mentor")) return "mentor";
+    if (normalized.includes("partner")) return "partner";
+    return "advisor";
+  }
+
+  private formatMatchName(match: { name?: string; company?: string; title?: string }): string {
+    if (match.name && match.company) {
+      return `${match.name}, ${match.company}`;
+    }
+    return match.name || "Unknown";
+  }
+
+  /**
+   * Generate AI-powered fallback matches using the mock client.
+   * Lazy-imported to avoid circular dependency.
+   */
+  private async generateFallbackMatches(request: MatchRequest): Promise<BoardyMatch[]> {
+    const { MockBoardyClient } = await import("./mock");
+    const mock = new MockBoardyClient();
+    return mock.getMatches(request);
+  }
+}

--- a/lib/boardy/types.ts
+++ b/lib/boardy/types.ts
@@ -51,12 +51,48 @@ export interface MatchRequest {
 }
 
 // ============================================================================
+// Boardy API Types
+// ============================================================================
+
+/** Request to initiate a Boardy AI call for founder profiling */
+export interface BoardyCallRequest {
+  phoneNumber: string;
+  name?: string;
+  email?: string;
+  slug?: string;
+}
+
+/** Response from Boardy call initiation */
+export interface BoardyCallResponse {
+  success: boolean;
+  message?: string;
+  referenceId?: string;
+}
+
+/** Webhook payload from Boardy when a match is found (double opt-in) */
+export interface BoardyWebhookPayload {
+  event: "match.created" | "match.accepted" | "match.declined" | "intro.completed";
+  referenceId: string;
+  match?: {
+    name: string;
+    title?: string;
+    company?: string;
+    type: string;
+    description?: string;
+    score?: number;
+    linkedinUrl?: string;
+  };
+  metadata?: Record<string, unknown>;
+  timestamp: string;
+}
+
+// ============================================================================
 // Client Interface (Strategy Pattern)
 // ============================================================================
 
 /**
  * BoardyClientInterface - abstraction for match generation.
- * Implementations: MockBoardyClient (AI-generated), future RealBoardyClient (API).
+ * Implementations: MockBoardyClient (AI-generated), RealBoardyClient (API).
  */
 export interface BoardyClientInterface {
   /** Get match suggestions for a user based on their profile */
@@ -67,6 +103,12 @@ export interface BoardyClientInterface {
 
   /** Get a deep link to the Boardy platform */
   getDeepLink(userId: string): string;
+
+  /** Request a Boardy AI call for founder profiling. Returns false if not supported. */
+  requestCall?(request: BoardyCallRequest): Promise<BoardyCallResponse>;
+
+  /** Whether this client connects to the real Boardy API */
+  readonly isLive: boolean;
 }
 
 // ============================================================================

--- a/lib/chat/upsell-detector.ts
+++ b/lib/chat/upsell-detector.ts
@@ -1,0 +1,183 @@
+/**
+ * Upsell Detection for FRED Chat
+ *
+ * Detects when a free-tier user is asking for Pro-tier features
+ * (document review, pitch deck improvement, storage, strategy docs)
+ * so FRED can offer a conversational, mentor-style upgrade nudge.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type UpsellTrigger =
+  | "pitch_deck_review"
+  | "doc_improvement"
+  | "doc_storage"
+  | "strategy_docs"
+  | "investor_readiness"
+
+export interface UpsellDetection {
+  /** Whether the message triggers an upsell opportunity */
+  detected: boolean
+  /** The specific feature the user is asking about */
+  trigger: UpsellTrigger | null
+  /** Confidence of the detection (0-1) */
+  confidence: number
+  /** Human-readable description for analytics */
+  featureLabel: string | null
+}
+
+// ============================================================================
+// Detection Patterns
+// ============================================================================
+
+interface DetectionRule {
+  trigger: UpsellTrigger
+  /** All patterns in at least one group must match (AND within group, OR across groups) */
+  patternGroups: RegExp[][]
+  featureLabel: string
+  /** Base confidence for this rule */
+  confidence: number
+}
+
+const DETECTION_RULES: DetectionRule[] = [
+  {
+    trigger: "pitch_deck_review",
+    patternGroups: [
+      [/pitch\s*deck/i, /review|grade|score|improv|fix|rewrite|analyz|assess|evaluat|feedback/i],
+      [/deck/i, /review|grade|score|improv|fix|better|stronger|rewrite|analyz|assess/i],
+      [/pitch/i, /review|grade|improv|fix|better|stronger|rewrite|polish/i],
+      [/grade\s+(my|the|our)\s+(pitch|deck)/i],
+      [/score\s+(my|the|our)\s+(pitch|deck)/i],
+      [/turn\s+(it|this|my\s+deck|the\s+deck)\s+into\s+an?\s+[A-F]/i],
+    ],
+    featureLabel: "Pitch Deck Review & Improvement",
+    confidence: 0.9,
+  },
+  {
+    trigger: "doc_improvement",
+    patternGroups: [
+      [/document|doc|report|plan|proposal|brief/i, /review|improv|fix|rewrite|edit|polish|refine|updat|enhanc/i],
+      [/help\s+(me\s+)?(with|write|create|draft|improve)/i, /document|doc|business\s*plan|executive\s*summary|one[- ]pager/i],
+      [/can\s+you\s+(review|improve|rewrite|fix|edit|polish)/i, /document|doc|report|plan|proposal/i],
+    ],
+    featureLabel: "Document Review & Improvement",
+    confidence: 0.85,
+  },
+  {
+    trigger: "doc_storage",
+    patternGroups: [
+      [/save|store|keep|upload|archive/i, /document|doc|deck|file|report|version/i],
+      [/document\s*(storage|vault|library|management)/i],
+      [/keep\s+(a\s+)?record|save\s+(this|my|the)\s+(work|progress|doc)/i],
+    ],
+    featureLabel: "Document Storage & Management",
+    confidence: 0.8,
+  },
+  {
+    trigger: "strategy_docs",
+    patternGroups: [
+      [/strateg(y|ic)/i, /document|doc|report|create|generat|build|write|draft/i],
+      [/create\s+(a\s+)?(go[- ]to[- ]market|gtm|market(ing)?|growth|business)\s*(strategy|plan|document|doc)/i],
+      [/positioning\s*(document|doc|framework|strategy)/i],
+    ],
+    featureLabel: "Strategy Documents",
+    confidence: 0.85,
+  },
+  {
+    trigger: "investor_readiness",
+    patternGroups: [
+      [/investor/i, /readiness|score|ready|prepared/i],
+      [/am\s+i\s+(investor\s+)?ready\s+(to\s+)?(raise|fundraise|pitch)/i],
+      [/investor\s*readiness\s*score/i],
+    ],
+    featureLabel: "Investor Readiness Score",
+    confidence: 0.85,
+  },
+]
+
+// ============================================================================
+// Detection Logic
+// ============================================================================
+
+/**
+ * Detect if a user message indicates interest in a Pro-tier feature.
+ * Returns the best-matching upsell trigger with confidence score.
+ */
+export function detectUpsellTrigger(message: string): UpsellDetection {
+  const noDetection: UpsellDetection = {
+    detected: false,
+    trigger: null,
+    confidence: 0,
+    featureLabel: null,
+  }
+
+  if (!message || message.length < 5) return noDetection
+
+  let bestMatch: UpsellDetection = noDetection
+
+  for (const rule of DETECTION_RULES) {
+    for (const group of rule.patternGroups) {
+      const allMatch = group.every((pattern) => pattern.test(message))
+      if (allMatch && rule.confidence > bestMatch.confidence) {
+        bestMatch = {
+          detected: true,
+          trigger: rule.trigger,
+          confidence: rule.confidence,
+          featureLabel: rule.featureLabel,
+        }
+      }
+    }
+  }
+
+  return bestMatch
+}
+
+// ============================================================================
+// Mentor-style upsell messages (Fred's voice)
+// ============================================================================
+
+const UPSELL_MESSAGES: Record<UpsellTrigger, string[]> = {
+  pitch_deck_review: [
+    "I can give you a quick score on your pitch deck right now — think of it as a gut-check grade. But if you want me to go slide-by-slide and actually *fix* it? That's where the Pro tier comes in. I've helped thousands of founders turn C-minus decks into ones that close rounds.",
+    "Here's what I can do right now — I'll grade your pitch deck and give you the high-level hits and misses. But turning a C into an A? That takes the deep-dive review. Upgrade to Pro and I'll tear it apart slide by slide and rebuild it with you.",
+    "Let me give you a quick score on that deck. Fair warning though — the real magic happens when I can do a full review and help you rewrite the weak spots. That's a Pro feature, and at $99/month, it's the cheapest fundraising advisor you'll ever find.",
+  ],
+  doc_improvement: [
+    "I can point you in the right direction here, but if you want me to actually roll up my sleeves and help you rewrite and improve your documents? That's Pro territory. Trust me — having an experienced eye edit your stuff is worth every penny.",
+    "Great question. I can give you general guidance right now, but the real value is when I can review, edit, and improve your documents directly. Upgrade to Pro and we'll work on this together.",
+  ],
+  doc_storage: [
+    "Right now your conversations with me reset each session. Upgrade to Pro and I'll remember everything — your docs, your progress, your strategy. It's like having a co-founder who never forgets.",
+    "Storage and persistent memory is a Pro feature. When you upgrade, I keep track of everything — your documents, your pitch iterations, your strategy evolution. Nothing falls through the cracks.",
+  ],
+  strategy_docs: [
+    "I can talk strategy all day — that's free. But when you're ready to actually *create* strategy documents, positioning frameworks, and go-to-market plans? That's where Pro comes in. I've built these for companies that went on to raise millions.",
+    "Strategy conversations? Absolutely, let's go. But generating actual strategy documents and frameworks — that's a Pro feature. Upgrade and I'll help you build the kind of strategic docs that make investors take notice.",
+  ],
+  investor_readiness: [
+    "You're asking the right question. I can give you a general sense of where you stand, but the full Investor Readiness Score — the one that breaks down exactly where you're strong and where you're vulnerable? That's Pro. And it's worth knowing before you walk into any pitch meeting.",
+    "Smart move checking your readiness. I can chat about it, but the detailed Investor Readiness Score that shows you exactly what VCs will scrutinize? That's a Pro feature. Upgrade and I'll give you the same assessment I'd give a company in my portfolio.",
+  ],
+}
+
+/**
+ * Get a random mentor-style upsell message for a given trigger.
+ */
+export function getUpsellMessage(trigger: UpsellTrigger): string {
+  const messages = UPSELL_MESSAGES[trigger]
+  return messages[Math.floor(Math.random() * messages.length)]
+}
+
+/**
+ * Feature descriptions for the upsell UI card
+ */
+export const PRO_TIER_HIGHLIGHTS = [
+  "Full Pitch Deck Review & Scorecard",
+  "Document Review & Improvement",
+  "Strategy Document Generation",
+  "Investor Readiness Score",
+  "Persistent Memory (30 days)",
+  "Priority AI Model (GPT-4o)",
+] as const

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -185,7 +185,7 @@ export function getTierFromString(tier: string): UserTier {
 export const MEMORY_CONFIG = {
   free: {
     maxMessages: 5,
-    retentionDays: 0,
+    retentionDays: 365,  // Store for 1 year (valuation + re-engagement). Loading is still disabled.
     loadEpisodic: false,
     maxEpisodicItems: 0,
   },

--- a/lib/fred/chat-voice-bridge.ts
+++ b/lib/fred/chat-voice-bridge.ts
@@ -77,13 +77,15 @@ export async function getChatContextForVoice(
  * Stores each transcript entry as an episodic memory record with channel='voice',
  * then appends a summary entry so that subsequent text chats see what was discussed.
  *
+ * Returns { stored, entriesStored, error } so callers can detect failures.
  * Non-throwing: logs warnings on failure, never propagates errors.
  */
 export async function injectVoiceTranscriptToChat(
   userId: string,
   roomName: string,
   transcript: VoiceTranscriptEntry[]
-): Promise<void> {
+): Promise<{ stored: boolean; entriesStored: number; error?: string }> {
+  let entriesStored = 0
   try {
     const sessionId = `voice-${roomName}`
 
@@ -94,6 +96,7 @@ export async function injectVoiceTranscriptToChat(
         roomName,
         voiceTimestamp: entry.timestamp,
       })
+      entriesStored++
     }
 
     // Build a brief summary from user and assistant messages
@@ -125,8 +128,13 @@ export async function injectVoiceTranscriptToChat(
         roomName,
       }
     )
+    entriesStored++
+
+    return { stored: true, entriesStored }
   } catch (err) {
+    const errorMsg = err instanceof Error ? err.message : String(err)
     console.warn("[Chat-Voice Bridge] Failed to inject voice transcript:", err)
+    return { stored: entriesStored > 0, entriesStored, error: errorMsg }
   }
 }
 

--- a/lib/hooks/use-fred-chat.ts
+++ b/lib/hooks/use-fred-chat.ts
@@ -432,6 +432,15 @@ export function useFredChat(options: UseFredChatOptions = {}): UseFredChatReturn
                 break;
               }
 
+              case "upsell": {
+                // Stage upsell prompt from server-side detection for the next assistant message
+                const upsellData = data as UpsellPrompt;
+                if (upsellData.trigger && upsellData.mentorMessage) {
+                  pendingUpsellRef.current = upsellData;
+                }
+                break;
+              }
+
               case "tool_result": {
                 // Detect recommendContent tool results and stage courses for the next assistant message
                 const toolResultData = data as {
@@ -537,6 +546,8 @@ export function useFredChat(options: UseFredChatOptions = {}): UseFredChatReturn
                   courses: pendingCoursesRef.current,
                   // Attach any staged provider recommendations from tool results
                   providers: pendingProvidersRef.current,
+                  // Attach any staged upsell prompt from server-side detection
+                  upsellPrompt: pendingUpsellRef.current,
                 };
 
                 if (mountedRef.current) {

--- a/lib/hooks/use-fred-chat.ts
+++ b/lib/hooks/use-fred-chat.ts
@@ -609,11 +609,19 @@ export function useFredChat(options: UseFredChatOptions = {}): UseFredChatReturn
       }
 
       // Silent auto-retry: transient failures (~20% first-message) usually succeed on retry.
-      // Remove any partial streaming message from the failed attempt before retrying.
+      // Preserve partial streaming content — if retry also fails, user keeps what was received.
       console.warn("[useFredChat] First attempt failed, retrying once:", firstErr);
+      let partialContent: string | null = null;
       if (streamingMessageIdRef.current && mountedRef.current) {
         const partialId = streamingMessageIdRef.current;
-        setMessages(prev => prev.filter(msg => msg.id !== partialId));
+        // Capture partial content before removing the streaming message
+        setMessages(prev => {
+          const partial = prev.find(msg => msg.id === partialId);
+          if (partial && partial.content && partial.content.length > 20) {
+            partialContent = partial.content;
+          }
+          return prev.filter(msg => msg.id !== partialId);
+        });
         streamingMessageIdRef.current = null;
       }
 
@@ -648,11 +656,14 @@ export function useFredChat(options: UseFredChatOptions = {}): UseFredChatReturn
           setError(errorMessage);
           setState("error");
 
-          // Add error message as assistant response
+          // If we captured partial content from the first attempt, show it with a note
+          // instead of losing the response entirely
           const errorResponseMessage: FredMessage = {
             id: crypto.randomUUID(),
             role: "assistant",
-            content: "I'm having trouble processing your message right now. Please try again.",
+            content: partialContent
+              ? `${partialContent}\n\n---\n*Connection was interrupted. This is a partial response — please try again for the full answer.*`
+              : "I'm having trouble processing your message right now. Please try again.",
             timestamp: new Date(),
             confidence: "low",
           };

--- a/lib/rlhf/patch-generator.ts
+++ b/lib/rlhf/patch-generator.ts
@@ -113,7 +113,7 @@ export async function generatePromptPatch(
     .map((p) => `- "${p.title}": ${p.content.slice(0, 100)}...`)
     .join("\n")
 
-  const prompt = `You are a prompt engineer improving an AI startup coaching assistant called FRED.
+  const prompt = `You are a prompt engineer improving an AI startup mentor called FRED.
 
 A recurring feedback pattern has been detected:
 

--- a/lib/sentiment/intervention-engine.ts
+++ b/lib/sentiment/intervention-engine.ts
@@ -28,10 +28,33 @@ export function generateIntervention(
   const nameRef = founderName || "the founder"
 
   if (signal.level === "critical") {
-    return `The founder shows signs of burnout or severe frustration (especially around ${topicStr}). Prioritize their wellbeing above all else. Suggest: "Before we continue, I think it's worth taking a breath. Would you like to do a quick wellbeing check-in? You can find it at /dashboard/wellbeing". Lead with empathy, not solutions. Acknowledge ${nameRef}'s persistence and dedication first. ${NATURALNESS_GUARD}`
+    return `The founder shows signs of burnout or severe frustration (especially around ${topicStr}).
+
+**PAUSE ALL BUSINESS TASKS.** Do NOT continue with startup advice, frameworks, or action items until the founder is in a better place.
+
+Instead:
+1. Acknowledge ${nameRef}'s dedication and validate their feelings
+2. Say something like: "Your business can wait a few days. You can't pour from an empty cup."
+3. Suggest concrete wellness actions: take a walk, call a friend, get a full night's sleep, do a breathing exercise
+4. Offer the wellbeing check-in: "When you're ready, we have a wellbeing check-in at /dashboard/wellbeing"
+5. Only return to business when THEY bring it back up — do not redirect back to tasks
+
+You are a mentor first, not a productivity machine. ${nameRef}'s health comes before their pitch deck. ${NATURALNESS_GUARD}`
   }
 
   // High stress
+  if (signal.trend === "worsening") {
+    return `The founder seems increasingly stressed about ${topicStr}. Their emotional state has been declining over recent conversations.
+
+**Slow down the business conversation.** Before giving any advice:
+1. Check in: "I can tell ${topicStr} is weighing on you. Before we dive back in — how are YOU doing?"
+2. Normalize it: "Every founder I've worked with has hit this wall. It's part of the journey."
+3. Suggest a pause if they need it: "Sometimes stepping away for a day or two gives you clarity no amount of grinding can."
+4. Only continue business advice if they explicitly want to
+
+Be warm and human. ${nameRef}'s feelings are valid and normal for founders at this stage. ${NATURALNESS_GUARD}`
+  }
+
   return `The founder seems stressed about ${topicStr}. Acknowledge their frustration before giving advice. Say something like: "I can tell ${topicStr} is weighing on you. Let's step back and look at this differently." Be warm and validating. Show ${nameRef} that their feelings are normal for founders at this stage. ${NATURALNESS_GUARD}`
 }
 

--- a/lib/sentiment/stress-detector.ts
+++ b/lib/sentiment/stress-detector.ts
@@ -60,10 +60,10 @@ const TOPIC_KEYWORDS: Record<string, string[]> = {
   product: ["product", "feature", "build", "ship", "launch", "mvp", "prototype", "bug"],
   team: ["team", "hire", "cofounder", "co-founder", "employee", "talent", "culture"],
   revenue: ["revenue", "sales", "customer", "churn", "mrr", "arr", "growth", "pricing"],
-  burnout: ["tired", "exhausted", "overwhelm", "burnout", "sleep", "stress", "anxiety", "quit"],
+  burnout: ["tired", "exhausted", "overwhelm", "burnout", "sleep", "stress", "anxiety", "quit", "can't sleep", "woke up", "insomnia", "panic", "breaking point", "giving up", "drowning", "falling apart", "crying", "can't stop thinking"],
   competition: ["competitor", "competition", "market share", "losing", "behind"],
   legal: ["legal", "lawsuit", "ip", "patent", "compliance", "regulation"],
-  personal: ["family", "health", "relationship", "lonely", "isolated", "depressed"],
+  personal: ["family", "health", "relationship", "lonely", "isolated", "depressed", "divorce", "sick", "hospital", "therapy", "counseling", "medication", "mental health", "suicidal", "worthless", "hopeless"],
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements 7 of 10 action items from the Sahara Founders Meeting (3/18/2026) with Fred Cary, William Hood, Julian, and Alex.

### Completed
- **Free-tier document quick-score** — New `/api/documents/quick-score` endpoint. Upload PDF, get AI letter grade (A-F) with summary. No storage for free users. Upsell messaging included.
- **In-chat upsell detection** — `lib/chat/upsell-detector.ts` pattern-matches 5 trigger types (pitch deck review, doc improvement, storage, strategy docs, investor readiness) with mentor-style upgrade nudges
- **Enhanced wellness detection** — Critical stress now **pauses ALL business tasks**, suggests concrete wellness activities. Expanded burnout keywords (insomnia, panic, breaking point, etc.)
- **Conversation history for ALL tiers** — `shouldPersistMemory` now stores unconditionally. Free tier retention changed from 0 to 365 days. Context loading still tier-gated (Pro+ only)
- **Brand copy audit** — "assistant" → "mentor", "Legal Assistant" → "Legal Advisor", "executive assistant" → "operations partner" across user-facing text
- **Business fundamentals enforcement** — Prevents generic Fred responses when core context is unknown
- **Boardy.ai prep** — Webhook, real client, call scheduling API routes for $249 tier

### Blocked (needs Fred/Vivi)
- Stripe API key integration (routes exist, just need credentials)
- 3-tier pricing activation (depends on Stripe)

### Linear Issues
AI-3578 through AI-3587 (7 Done, 1 Blocked, 2 Pending)

## Test plan
- [ ] Verify `/api/documents/quick-score` returns letter grade for uploaded PDF
- [ ] Verify free-tier users get upsell prompts when asking about Pro features in chat
- [ ] Verify critical stress messages trigger wellness pause (test with "I can't sleep, I'm falling apart")
- [ ] Verify free-tier conversations are stored in `fred_episodic_memory` table
- [ ] Verify "mentor" language appears instead of "assistant" in agents page and voice config
- [ ] Smoke test Fred chat to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)