### PR TITLE
fix: resolve live deck URL 404s with route aliases

### DIFF
--- a/app/dashboard/deck/page.tsx
+++ b/app/dashboard/deck/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation"
+
+export default function DashboardDeckAliasPage() {
+  redirect("/dashboard/pitch-deck")
+}

--- a/app/deck/page.tsx
+++ b/app/deck/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation"
 
 export default function DeckPage() {
-  redirect("/dashboard/pitch-deck")
+  redirect("/demo/pitch-deck")
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -35,6 +35,10 @@ export async function middleware(request: NextRequest) {
   const start = Date.now();
 
   const { pathname } = request.nextUrl;
+  const normalizedPath =
+    pathname !== "/" && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
   const origin = request.headers.get("origin");
 
   // Phase 25-02: Correlation ID for structured logging
@@ -67,6 +71,26 @@ export async function middleware(request: NextRequest) {
       for (const [key, value] of Object.entries(hdrs)) {
         response.headers.set(key, value);
       }
+    }
+
+    // Deck URL aliases: route short/legacy paths to canonical locations.
+    // Logged-out users should see the public demo, while authenticated users
+    // should land on the full dashboard review experience.
+    if (normalizedPath === "/deck" || normalizedPath === "/pitch-deck") {
+      const destination = user ? "/dashboard/pitch-deck" : "/demo/pitch-deck";
+      const deckUrl = new URL(destination, request.url);
+      deckUrl.search = request.nextUrl.search;
+      const redirectResponse = NextResponse.redirect(deckUrl);
+      redirectResponse.headers.set("X-Request-ID", requestId);
+      return redirectResponse;
+    }
+
+    if (normalizedPath === "/dashboard/deck") {
+      const dashboardDeckUrl = new URL("/dashboard/pitch-deck", request.url);
+      dashboardDeckUrl.search = request.nextUrl.search;
+      const redirectResponse = NextResponse.redirect(dashboardDeckUrl);
+      redirectResponse.headers.set("X-Request-ID", requestId);
+      return redirectResponse;
     }
 
     // Check if this route requires authentication


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add robust alias handling for legacy deck URLs in `middleware.ts`
  - `/deck` and `/pitch-deck` now redirect to:
    - `/dashboard/pitch-deck` for authenticated users
    - `/demo/pitch-deck` for logged-out users
  - `/dashboard/deck` now redirects to `/dashboard/pitch-deck`
- keep explicit route aliases in App Router:
  - `app/deck/page.tsx` now redirects to `/demo/pitch-deck` (public-safe fallback)
  - new `app/dashboard/deck/page.tsx` redirects to `/dashboard/pitch-deck`

## Why this change
- live traffic can hit short/legacy deck URLs that were not mapped
- this avoids 404s and routes users to the correct experience based on auth state

## Verification
- validated route/middleware logic in code
- unable to run lint/build checks in this environment because local tooling is unavailable (`eslint: not found`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="[https://cursor.com/agents/bc-7a82cc97-08b7-4fc5-a093-1f2aa31993cb](https://cursor.com/agents/bc-7a82cc97-08b7-4fc5-a093-1f2aa31993cb)"><picture><source media="(prefers-color-scheme: dark)" srcset="[https://cursor.com/assets/images/open-in-web-dark.png](https://cursor.com/assets/images/open-in-web-dark.png)"><source media="(prefers-color-scheme: light)" srcset="[https://cursor.com/assets/images/open-in-web-light.png](https://cursor.com/assets/images/open-in-web-light.png)"><img alt="Open in Web" width="114" height="28" src="[https://cursor.com/assets/images/open-in-web-dark.png](https://cursor.com/assets/images/open-in-web-dark.png)"></picture></a>&nbsp;<a href="[https://cursor.com/background-agent?bcId=bc-7a82cc97-08b7-4fc5-a093-1f2aa31993cb](https://cursor.com/background-agent?bcId=bc-7a82cc97-08b7-4fc5-a093-1f2aa31993cb)"><picture><source media="(prefers-color-scheme: dark)" srcset="[https://cursor.com/assets/images/open-in-cursor-dark.png](https://cursor.com/assets/images/open-in-cursor-dark.png)"><source media="(prefers-color-scheme: light)" srcset="[https://cursor.com/assets/images/open-in-cursor-light.png](https://cursor.com/assets/images/open-in-cursor-light.png)"><img alt="Open in Cursor" width="131" height="28" src="[https://cursor.com/assets/images/open-in-cursor-dark.png](https://cursor.com/assets/images/open-in-cursor-dark.png)"></picture></a>&nbsp;</div>

