### PR TITLE
[Sahara P1] Restore AI provider fallback chain with circuit breaker

### DIFF
--- a/lib/ai/circuit-breaker.ts
+++ b/lib/ai/circuit-breaker.ts
@@ -58,9 +58,9 @@ export interface CircuitBreakerMetrics {
 // ============================================================================
 
 const DEFAULT_CONFIG: CircuitBreakerConfig = {
-  failureThreshold: 5,
+  failureThreshold: 3,
   resetTimeout: 30000, // 30 seconds
-  halfOpenRequests: 3,
+  halfOpenRequests: 2,
   monitoringWindow: 60000, // 1 minute
 };
 

--- a/lib/ai/fred-client.ts
+++ b/lib/ai/fred-client.ts
@@ -113,42 +113,44 @@ export async function generate(
   prompt: string,
   options: GenerateOptions = {}
 ): Promise<GenerateResult> {
-  const model = getModel(options.model || "primary");
+  // Use fallback chain with circuit breaker for automatic failover
+  const fallbackResult = await executeWithFallback(
+    async (_provider, model) => {
+      const result = streamText({
+        model,
+        prompt,
+        system: options.system,
+        maxOutputTokens: options.maxOutputTokens ?? 4096,
+        temperature: options.temperature ?? 0.7,
+        abortSignal: options.abortSignal,
+        ...(options.tools ? { tools: options.tools } : {}),
+        ...(options.tools && options.maxSteps
+          ? { stopWhen: stepCountIs(options.maxSteps) }
+          : {}),
+      });
 
-  // Use streamText internally to reduce TTFB — the OpenAI API begins returning
-  // tokens faster in streaming mode. Awaiting `result.text` auto-consumes the
-  // stream and collects the full response, so callers still get a complete
-  // GenerateResult.
-  const result = streamText({
-    model,
-    prompt,
-    system: options.system,
-    maxOutputTokens: options.maxOutputTokens ?? 4096,
-    temperature: options.temperature ?? 0.7,
-    abortSignal: options.abortSignal,
-    ...(options.tools ? { tools: options.tools } : {}),
-    ...(options.tools && options.maxSteps
-      ? { stopWhen: stepCountIs(options.maxSteps) }
-      : {}),
-  });
+      const [text, usage, finishReason, response] = await Promise.all([
+        result.text,
+        result.usage,
+        result.finishReason,
+        result.response,
+      ]);
 
-  const [text, usage, finishReason, response] = await Promise.all([
-    result.text,
-    result.usage,
-    result.finishReason,
-    result.response,
-  ]);
-
-  return {
-    text,
-    usage: {
-      promptTokens: usage.inputTokens ?? 0,
-      completionTokens: usage.outputTokens ?? 0,
-      totalTokens: (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0),
+      return {
+        text,
+        usage: {
+          promptTokens: usage.inputTokens ?? 0,
+          completionTokens: usage.outputTokens ?? 0,
+          totalTokens: (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0),
+        },
+        finishReason,
+        modelId: response?.modelId ?? "unknown",
+      };
     },
-    finishReason,
-    modelId: response?.modelId ?? "unknown",
-  };
+    { enableRetry: true, retryPreset: "standard" }
+  );
+
+  return fallbackResult.result;
 }
 
 /**
@@ -165,35 +167,40 @@ export async function generateFromMessages(
   messages: ModelMessage[],
   options: GenerateOptions = {}
 ): Promise<GenerateResult> {
-  const model = getModel(options.model || "primary");
+  // Use fallback chain with circuit breaker for automatic failover
+  const fallbackResult = await executeWithFallback(
+    async (_provider, model) => {
+      const result = streamText({
+        model,
+        messages,
+        system: options.system,
+        maxOutputTokens: options.maxOutputTokens ?? 4096,
+        temperature: options.temperature ?? 0.7,
+        abortSignal: options.abortSignal,
+      });
 
-  // Use streamText internally to reduce TTFB (same optimization as generate())
-  const result = streamText({
-    model,
-    messages,
-    system: options.system,
-    maxOutputTokens: options.maxOutputTokens ?? 4096,
-    temperature: options.temperature ?? 0.7,
-    abortSignal: options.abortSignal,
-  });
+      const [text, usage, finishReason, response] = await Promise.all([
+        result.text,
+        result.usage,
+        result.finishReason,
+        result.response,
+      ]);
 
-  const [text, usage, finishReason, response] = await Promise.all([
-    result.text,
-    result.usage,
-    result.finishReason,
-    result.response,
-  ]);
-
-  return {
-    text,
-    usage: {
-      promptTokens: usage.inputTokens ?? 0,
-      completionTokens: usage.outputTokens ?? 0,
-      totalTokens: (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0),
+      return {
+        text,
+        usage: {
+          promptTokens: usage.inputTokens ?? 0,
+          completionTokens: usage.outputTokens ?? 0,
+          totalTokens: (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0),
+        },
+        finishReason,
+        modelId: response?.modelId ?? "unknown",
+      };
     },
-    finishReason,
-    modelId: response?.modelId ?? "unknown",
-  };
+    { enableRetry: true, retryPreset: "standard" }
+  );
+
+  return fallbackResult.result;
 }
 
 // ============================================================================

--- a/lib/ai/index.ts
+++ b/lib/ai/index.ts
@@ -55,6 +55,18 @@ export {
   type EmbeddingConfig,
 } from "./providers";
 
+// Circuit breaker and fallback chain
+export { circuitBreaker, type CircuitBreakerMetrics } from "./circuit-breaker";
+export {
+  executeWithFallback,
+  getBestAvailableProvider,
+  getHealthyProviders,
+  getProviderAvailability,
+  type ProviderName,
+  type FallbackConfig,
+} from "./fallback-chain";
+export { healthMonitor } from "./health-monitor";
+
 // Structured output schemas
 export * from "./schemas";
 


### PR DESCRIPTION
## Summary
- Wired circuit breaker + fallback chain into core `generate()` and `generateFromMessages()` functions
- If primary provider fails 3x in 60s, circuit opens and auto-fails over to Anthropic/Google
- Exported `circuitBreaker`, `healthMonitor`, and fallback chain utilities from `lib/ai/index.ts`
- Existing infrastructure (`circuit-breaker.ts`, `fallback-chain.ts`, `health-monitor.ts`, `retry.ts`) was already in place but not connected to the main generation functions

## What was wrong
The `generate()` and `generateFromMessages()` functions used `getModel()` directly, which only checked for API key presence — not runtime health. If OpenAI went down mid-request, it threw without trying Anthropic or Google. With 250 founders at a live demo, a provider outage = total Fred failure.

## What's fixed
- `generate()` now uses `executeWithFallback()` which wraps each call in the circuit breaker
- If OpenAI fails, it auto-retries with exponential backoff, then falls back to Anthropic, then Google
- Circuit breaker threshold: 3 failures in 60s = open circuit (was 5)
- Health endpoint at `/api/health/ai` shows real-time provider status

## Verification
- `npx tsc --noEmit` passes cleanly
- Test with: `POST /api/health/ai` (requires admin auth) to trigger fresh health checks
- Monitor circuit state: `GET /api/health/ai`

Linear: AI-5244

🤖 Generated with [Claude Code](https://claude.com/claude-code)