### PR TITLE
[Sahara P1] Fix voice chat cutoff on Samsung devices

### DIFF
--- a/components/dashboard/call-fred-modal.tsx
+++ b/components/dashboard/call-fred-modal.tsx
@@ -462,6 +462,25 @@ export function CallFredModal({
         console.log('[CallFred] SignalConnected');
       });
 
+      // Samsung: Immediate mic recovery on TrackMuted event (faster than polling).
+      // Samsung browsers can silently mute the local mic track without user action.
+      if (isSamsungDevice()) {
+        room.on(RoomEvent.TrackMuted, (publication, participant) => {
+          if (
+            participant.identity === room.localParticipant.identity &&
+            publication.source === Track.Source.Microphone &&
+            !isMutedRef.current
+          ) {
+            console.warn('[CallFred] Samsung: Local mic track was muted unexpectedly, re-enabling...');
+            const audioOpts = buildAudioCaptureOptions();
+            room.localParticipant
+              .setMicrophoneEnabled(true, audioOpts)
+              .then(() => console.log('[CallFred] Samsung: Mic restored via TrackMuted handler'))
+              .catch((e) => console.warn('[CallFred] Samsung TrackMuted re-enable failed:', e));
+          }
+        });
+      }
+
       // P1 Fix: Timeout if agent doesn't join within 30 seconds
       const hasRemoteParticipant = room.remoteParticipants.size > 0;
       if (!hasRemoteParticipant) {
@@ -489,6 +508,7 @@ export function CallFredModal({
       // Samsung workaround: Monitor local audio track for silent muting.
       // Samsung Internet can silently mute the track (track.isMuted becomes true)
       // without firing MediaDevicesError. Poll and re-enable if detected.
+      // Also detect fully ended tracks which Samsung can kill during focus loss.
       if (isSamsungDevice()) {
         samsungWatchdogRef.current = setInterval(() => {
           const currentRoom = roomRef.current;
@@ -507,7 +527,20 @@ export function CallFredModal({
               .setMicrophoneEnabled(true, audioOpts)
               .catch((e) => console.warn('[CallFred] Samsung mic re-enable failed:', e));
           }
-        }, 3000);
+
+          // Detect fully ended tracks — Samsung can kill the underlying MediaStreamTrack
+          // entirely when the notification drawer opens or after an OS-level interruption.
+          // In this case, the track won't be muted — it'll be missing. Re-acquire mic.
+          if (!micPub || (micPub.track?.mediaStreamTrack?.readyState === "ended" && !isMutedRef.current)) {
+            console.warn('[CallFred] Samsung: Mic track ended or missing, re-acquiring...');
+            const audioOpts = buildAudioCaptureOptions();
+            currentRoom.localParticipant
+              .setMicrophoneEnabled(false)
+              .then(() => currentRoom.localParticipant.setMicrophoneEnabled(true, audioOpts))
+              .then(() => console.log('[CallFred] Samsung: Mic re-acquired successfully'))
+              .catch((e) => console.warn('[CallFred] Samsung mic re-acquire failed:', e));
+          }
+        }, 2000); // Poll every 2s (was 3s — Samsung suspensions can happen fast)
       }
     } catch (err) {
       console.error("[CallFred] Error starting call:", err);

--- a/lib/hooks/use-whisper-flow.ts
+++ b/lib/hooks/use-whisper-flow.ts
@@ -51,6 +51,24 @@ interface UseWhisperFlowOptions {
   autoSend?: boolean;
 }
 
+// ============================================================================
+// Samsung / Android Browser Detection
+// ============================================================================
+
+/**
+ * Detect Samsung Internet or Samsung Galaxy devices where audio recording
+ * cuts off due to aggressive track suspension and incompatible constraints.
+ */
+function isSamsungDevice(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent.toLowerCase();
+  return (
+    ua.includes("samsungbrowser") ||
+    ua.includes("samsung") ||
+    /sm-[gasn]\d/i.test(navigator.userAgent)
+  );
+}
+
 // Preferred MIME types in order of quality/compatibility
 const MIME_TYPES = [
   "audio/webm;codecs=opus",
@@ -197,14 +215,31 @@ export function useWhisperFlow(options: UseWhisperFlowOptions = {}): UseWhisperF
     setDuration(0);
     chunksRef.current = [];
 
+    const samsung = isSamsungDevice();
+
     try {
+      // Samsung audio HALs conflict with autoGainControl and specific sampleRates.
+      // Use relaxed constraints to prevent the browser from killing the mic track.
+      const audioConstraints: MediaTrackConstraints = samsung
+        ? {
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: false,
+            channelCount: 1,
+          }
+        : {
+            echoCancellation: true,
+            noiseSuppression: true,
+            autoGainControl: true,
+            sampleRate: { ideal: 16000 },
+          };
+
+      if (samsung) {
+        console.log("[WhisperFlow] Samsung device detected, using compatible audio constraints");
+      }
+
       const stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          echoCancellation: true,
-          noiseSuppression: true,
-          autoGainControl: true,
-          sampleRate: { ideal: 16000 },
-        },
+        audio: audioConstraints,
       });
 
       streamRef.current = stream;
@@ -250,8 +285,41 @@ export function useWhisperFlow(options: UseWhisperFlowOptions = {}): UseWhisperF
         stream.getTracks().forEach((t) => t.stop());
       };
 
+      // Samsung Internet can silently kill the audio track without firing
+      // recorder.onerror. Monitor the track's "ended" event to catch this.
+      const audioTrack = stream.getAudioTracks()[0];
+      if (audioTrack) {
+        audioTrack.addEventListener("ended", () => {
+          // Only handle unexpected track ends (not user-initiated stops)
+          if (mediaRecorderRef.current && mediaRecorderRef.current.state === "recording") {
+            console.warn("[WhisperFlow] Audio track ended unexpectedly (Samsung suspension)");
+            // Stop the recorder gracefully so whatever was captured gets transcribed
+            try {
+              mediaRecorderRef.current.stop();
+            } catch {
+              // Recorder may already be stopped
+            }
+            mediaRecorderRef.current = null;
+            setIsRecording(false);
+          }
+        });
+
+        // Samsung: watch for the track being muted (different from ended).
+        // This happens when the notification drawer opens or the tab loses focus.
+        if (samsung) {
+          audioTrack.addEventListener("mute", () => {
+            console.warn("[WhisperFlow] Samsung: audio track muted, track may recover on unmute");
+          });
+          audioTrack.addEventListener("unmute", () => {
+            console.log("[WhisperFlow] Samsung: audio track unmuted, recording continues");
+          });
+        }
+      }
+
       mediaRecorderRef.current = recorder;
-      recorder.start(1000); // Collect data every second
+      // Samsung: Use shorter timeslice (500ms) to minimize data loss if the
+      // browser suspends the track mid-recording. Other browsers use 1s.
+      recorder.start(samsung ? 500 : 1000);
       startTimeRef.current = Date.now();
       setIsRecording(true);
 
@@ -259,6 +327,17 @@ export function useWhisperFlow(options: UseWhisperFlowOptions = {}): UseWhisperF
       timerRef.current = setInterval(() => {
         setDuration(Math.floor((Date.now() - startTimeRef.current) / 1000));
       }, 500);
+
+      // Resume AudioContext first on Samsung (autoplay policy can block it)
+      if (samsung) {
+        try {
+          const ctx = new AudioContext();
+          if (ctx.state === "suspended") await ctx.resume();
+          await ctx.close();
+        } catch {
+          // Non-critical — level monitoring may not work but recording still will
+        }
+      }
 
       // Start audio level monitoring for visualizations
       startAudioLevelMonitoring(stream);


### PR DESCRIPTION
## Summary
- Add Samsung device detection and audio constraint workarounds to both voice systems (LiveKit calls + Whisper recording)
- Disable `autoGainControl` and relax `sampleRate` constraints on Samsung (HAL conflicts cause track suspension)
- Add `TrackMuted` event handler for immediate mic recovery + tighten watchdog polling from 3s to 2s
- Detect fully ended `MediaStreamTrack` (Samsung kills tracks on focus loss) and re-acquire mic automatically
- Add track `ended`/`mute`/`unmute` listeners in Whisper flow for graceful degradation on Samsung
- Use 500ms recording timeslice on Samsung to minimize data loss during suspensions

## Files Changed
- `lib/hooks/use-whisper-flow.ts` — Samsung detection, compatible audio constraints, track event listeners
- `components/dashboard/call-fred-modal.tsx` — TrackMuted handler, tighter watchdog, track-ended recovery

## Verification
- Test on Samsung Galaxy S23/S24 with Samsung Internet and Chrome
- Verify 5+ minute sustained voice call without drops
- Verify Whisper voice recording completes full message without cutoff
- Test notification drawer pull-down during active call (should auto-recover)
- Confirm non-Samsung devices are unaffected (Samsung codepaths gated behind `isSamsungDevice()`)

Linear: AI-5239

🤖 Generated with [Claude Code](https://claude.com/claude-code)