### PR TITLE
fix: correct misleading website statistics (AI-2649)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -18,7 +18,7 @@ import {
 const stats = [
   { value: "100s+", label: "Founders Coached" },
   { value: "50+", label: "Years Experience" },
-  { value: "$1B+", label: "Capital Raised" },
+  { value: "$3B+", label: "Capital Raised" },
   { value: "40+", label: "Companies Founded" },
 ];
 

--- a/app/deck/deck-content.tsx
+++ b/app/deck/deck-content.tsx
@@ -8,7 +8,7 @@ const teamMembers = [
   {
     name: "Fred Cary",
     title: "Chairman",
-    stats: "400+ startups launched | $2B+ raised | $1B+ ARR track record.",
+    stats: "400+ startups launched | $3B+ raised | $1B+ ARR track record.",
     tagline: "Architect of institutional structure.",
     image: "/deck/fred-cary.jpg",
     initials: "FC",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,7 +28,7 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "https://joinsahara.com"),
   title: "Sahara | AI-Powered Founder Operating System",
-  description: "Think Clearer. Raise Smarter. Scale Faster. Sahara is the AI-powered operating system for startup founders. Built by Fred Cary — hundreds of founders coached, $1B+ raised.",
+  description: "Think Clearer. Raise Smarter. Scale Faster. Sahara is the AI-powered operating system for startup founders. Built by Fred Cary — hundreds of founders coached, $3B+ raised.",
   keywords: ["startup", "founder", "fundraising", "investor", "pitch deck", "venture capital", "AI", "Sahara", "Fred Cary"],
   manifest: "/manifest.webmanifest",
   icons: {

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -55,7 +55,7 @@ const Footer = () => {
             </Link>
             <p className="text-sm text-gray-600 dark:text-gray-400 max-w-sm">
               The AI-powered decision operating system for startup founders.
-              Built by Fred Cary — hundreds of founders coached, $1B+ raised.
+              Built by Fred Cary — hundreds of founders coached, $3B+ raised.
             </p>
             <Button
               asChild

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -171,7 +171,7 @@ export default function Hero() {
           <div className="flex flex-wrap justify-center gap-6 sm:gap-8 mb-10">
             {[
               { icon: Users, text: "Hundreds of Founders Coached" },
-              { icon: CheckIcon, text: "$1B+ Raised" },
+              { icon: CheckIcon, text: "$3B+ Raised" },
               { icon: Sparkles, text: "By Fred Cary" },
             ].map((item, i) => (
               <div

--- a/components/stats.tsx
+++ b/components/stats.tsx
@@ -39,7 +39,7 @@ function AnimatedCounter({ end, suffix = "", prefix = "" }: { end: number; suffi
 export default function Stats() {
   const stats = [
     { number: 100, prefix: "", suffix: "s+", label: "Founders Coached" },
-    { number: 1, prefix: "$", suffix: "B+", label: "Capital Raised" },
+    { number: 3, prefix: "$", suffix: "B+", label: "Capital Raised" },
     { number: 500, prefix: "", suffix: "+", label: "Decks Reviewed" },
     { number: 89, prefix: "", suffix: "%", label: "Investor Meeting Rate" },
   ];

--- a/components/testimonials.tsx
+++ b/components/testimonials.tsx
@@ -1,113 +1,8 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { FadeUpOnScroll } from "@/components/premium/AnimatedText";
-import { QuoteIcon } from "@radix-ui/react-icons";
 
 export default function Testimonials() {
-  const testimonials = [
-    {
-      name: "Sarah Chen",
-      role: "Founder, HealthTech Startup",
-      avatar: "SC",
-      content:
-        "The Decision OS told me honestly that I wasn't ready to raise. It hurt to hear, but 6 months later I closed my seed round in 3 weeks. That honesty saved me from burning bridges.",
-      rating: 5,
-      gradient: "from-[#ff6a1a] to-orange-400",
-      glowColor: "rgba(255, 106, 26, 0.3)",
-    },
-    {
-      name: "Marcus Rodriguez",
-      role: "CEO, AI Infrastructure",
-      avatar: "MR",
-      content:
-        "The Investor Readiness Score changed everything. I knew exactly what to fix before my first pitch. Went from 0% response rate to 40% meeting rate in one month.",
-      rating: 5,
-      gradient: "from-amber-500 to-[#ff6a1a]",
-      glowColor: "rgba(245, 158, 11, 0.3)",
-    },
-    {
-      name: "Emma Thompson",
-      role: "Solo Founder, B2B SaaS",
-      avatar: "ET",
-      content:
-        "The virtual team agents are like having a chief of staff. My inbox is managed, my fundraise is organized, and I can finally focus on building product.",
-      rating: 5,
-      gradient: "from-orange-500 to-red-500",
-      glowColor: "rgba(249, 115, 22, 0.3)",
-    },
-    {
-      name: "James Wilson",
-      role: "First-time Founder",
-      avatar: "JW",
-      content:
-        "I started with the free tier just to think through my idea. The Reality Lens caught 3 fatal flaws I would have discovered the hard way. Worth every minute.",
-      rating: 5,
-      gradient: "from-[#ff6a1a] to-amber-400",
-      glowColor: "rgba(255, 106, 26, 0.25)",
-    },
-    {
-      name: "Maria Garcia",
-      role: "Founder, FinTech",
-      avatar: "MG",
-      content:
-        "Boardy connected me with the perfect Series A leads. The warm intro workflow is what convinced me to upgrade — and it paid for itself in one meeting.",
-      rating: 5,
-      gradient: "from-orange-600 to-[#ff6a1a]",
-      glowColor: "rgba(234, 88, 12, 0.3)",
-    },
-    {
-      name: "Kevin Lee",
-      role: "Technical Founder",
-      avatar: "KL",
-      content:
-        "I'm a builder, not a fundraiser. The pitch deck review and strategy documents gave me the language and structure to communicate my vision. Closed $2M pre-seed.",
-      rating: 5,
-      gradient: "from-amber-400 to-orange-500",
-      glowColor: "rgba(251, 191, 36, 0.3)",
-    },
-    {
-      name: "Sophie Anderson",
-      role: "Second-time Founder",
-      avatar: "SA",
-      content:
-        "Even as an experienced founder, the weekly check-ins keep me accountable. It's like having a co-founder who never misses a beat.",
-      rating: 5,
-      gradient: "from-[#ff6a1a] to-orange-400",
-      glowColor: "rgba(255, 106, 26, 0.3)",
-    },
-    {
-      name: "David Park",
-      role: "Founder, Climate Tech",
-      avatar: "DP",
-      content:
-        "The Red Flag Detection caught a co-founder issue I was ignoring. Hard conversation, but saved the company. This thing is brutally honest — exactly what founders need.",
-      rating: 5,
-      gradient: "from-orange-500 to-amber-500",
-      glowColor: "rgba(249, 115, 22, 0.3)",
-    },
-    {
-      name: "Elena Petrov",
-      role: "Founder, EdTech",
-      avatar: "EP",
-      content:
-        "From idea validation to Series A strategy docs, this platform grew with me. The 30/60/90 planning alone is worth the subscription.",
-      rating: 5,
-      gradient: "from-amber-500 to-[#ff6a1a]",
-      glowColor: "rgba(245, 158, 11, 0.3)",
-    },
-  ];
-
-  const StarIcon = () => (
-    <svg
-      className="w-4 h-4 text-yellow-400 drop-shadow-sm"
-      fill="currentColor"
-      viewBox="0 0 20 20"
-    >
-      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-    </svg>
-  );
-
   return (
     <section id="testimonials" className="scroll-mt-20 relative py-24 sm:py-32 overflow-hidden bg-gray-50 dark:bg-gray-900">
       {/* Background blobs */}
@@ -130,114 +25,12 @@ export default function Testimonials() {
       </div>
 
       <div className="relative z-10 container mx-auto px-4 sm:px-6 lg:px-8">
-        {/* Section header */}
-        <motion.div
-          initial={{ opacity: 0, y: 30 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.8 }}
-          className="text-center mb-16 sm:mb-20"
-        >
-          <motion.span
-            initial={{ opacity: 0, scale: 0.9 }}
-            whileInView={{ opacity: 1, scale: 1 }}
-            viewport={{ once: true }}
-            className="inline-block text-sm font-semibold tracking-wider text-[#ff6a1a] bg-[#ff6a1a]/10 px-4 py-2 rounded-full border border-[#ff6a1a]/20 mb-6"
-          >
-            TESTIMONIALS
-          </motion.span>
-          <h2 className="text-4xl sm:text-5xl md:text-6xl font-bold mb-6 text-gray-900 dark:text-white">
-            Trusted by <span className="text-[#ff6a1a]">Hundreds of</span> Founders
-          </h2>
-          <p className="mx-auto max-w-2xl text-lg sm:text-xl text-gray-600 dark:text-gray-400">
-            Real founders sharing their honest experience with the Decision OS.
-            No filters. No BS.
-          </p>
-        </motion.div>
-
-        {/* Testimonials masonry grid */}
-        <div className="columns-1 md:columns-2 lg:columns-3 gap-6 sm:gap-8 space-y-6 sm:space-y-8">
-          {testimonials.map((testimonial, index) => (
-            <motion.div
-              key={index}
-              initial={{ opacity: 0, y: 30 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{
-                duration: 0.6,
-                delay: index * 0.08,
-                ease: "easeOut",
-              }}
-              className="break-inside-avoid"
-            >
-              <motion.div
-                whileHover={{ y: -5, scale: 1.02 }}
-                transition={{ duration: 0.3 }}
-                className="group relative"
-              >
-                {/* Glow effect on hover */}
-                <div
-                  className="absolute inset-0 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-xl -z-10"
-                  style={{ background: testimonial.glowColor }}
-                />
-
-                {/* Card */}
-                <div className="relative bg-white dark:bg-gray-950 rounded-2xl p-6 sm:p-8 border border-gray-200 dark:border-gray-800 group-hover:border-[#ff6a1a]/30 transition-all duration-300 overflow-hidden shadow-sm hover:shadow-lg">
-                  {/* Quote icon */}
-                  <div className={`absolute top-4 right-4 w-10 h-10 rounded-lg bg-gradient-to-br ${testimonial.gradient} opacity-20 flex items-center justify-center`}>
-                    <QuoteIcon className="w-5 h-5 text-white" />
-                  </div>
-
-                  {/* Content */}
-                  <div className="relative z-10">
-                    {/* Rating */}
-                    <div className="flex gap-1 mb-4">
-                      {[...Array(testimonial.rating)].map((_, i) => (
-                        <StarIcon key={i} />
-                      ))}
-                    </div>
-
-                    {/* Quote */}
-                    <p className="text-gray-600 dark:text-gray-400 leading-relaxed mb-6 text-sm sm:text-base">
-                      &ldquo;{testimonial.content}&rdquo;
-                    </p>
-
-                    {/* Author */}
-                    <div className="flex items-center gap-4">
-                      <div
-                        className={`w-12 h-12 rounded-full bg-gradient-to-br ${testimonial.gradient} flex items-center justify-center text-white font-bold text-sm shadow-lg`}
-                        style={{ boxShadow: `0 8px 24px ${testimonial.glowColor}` }}
-                      >
-                        {testimonial.avatar}
-                      </div>
-                      <div>
-                        <h4 className="font-semibold text-gray-900 dark:text-white group-hover:text-[#ff6a1a] transition-all duration-300">
-                          {testimonial.name}
-                        </h4>
-                        <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400">
-                          {testimonial.role}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Corner decoration */}
-                  <div
-                    className={`absolute -bottom-8 -right-8 w-24 h-24 rounded-full bg-gradient-to-r ${testimonial.gradient} opacity-10 blur-2xl group-hover:opacity-20 transition-opacity`}
-                  />
-                </div>
-              </motion.div>
-            </motion.div>
-          ))}
-        </div>
-
         {/* Social proof banner */}
         <motion.div
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.8, delay: 0.3 }}
-          className="mt-16 sm:mt-24"
         >
           <div className="relative bg-white dark:bg-gray-950 rounded-2xl p-8 sm:p-12 border border-gray-200 dark:border-gray-800 text-center overflow-hidden shadow-lg">
             {/* Background gradient */}
@@ -253,15 +46,15 @@ export default function Testimonials() {
               <div className="flex flex-wrap justify-center gap-8 text-sm text-gray-600 dark:text-gray-400">
                 <div className="flex items-center gap-2">
                   <div className="w-2 h-2 bg-[#ff6a1a] rounded-full" />
-                  <span>Billions raised by users</span>
+                  <span>$3B+ raised</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <div className="w-2 h-2 bg-orange-400 rounded-full" />
-                  <span>Proven investor meeting results</span>
+                  <span>50+ years of experience</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <div className="w-2 h-2 bg-amber-500 rounded-full" />
-                  <span>500+ decks reviewed</span>
+                  <span>Hundreds of founders coached</span>
                 </div>
               </div>
             </div>

--- a/funnel/src/pages/LandingPage.tsx
+++ b/funnel/src/pages/LandingPage.tsx
@@ -150,7 +150,7 @@ export function LandingPage({ onStartChat }: LandingPageProps) {
             transition={{ duration: 0.4, delay: 0.2 }}
             className="text-base text-gray-600 mb-6 leading-relaxed"
           >
-            Fred Cary has coached hundreds of founders and helped raise billions. Now his
+            Fred Cary has coached hundreds of founders and helped raise over $3B. Now his
             experience is available 24/7 as your AI co-founder.
           </motion.p>
 
@@ -192,7 +192,7 @@ export function LandingPage({ onStartChat }: LandingPageProps) {
             </span>
             <span className="flex items-center gap-1.5">
               <Sparkles className="w-3.5 h-3.5 text-[#ff6a1a]" />
-              Billions Raised
+              $3B+ Raised
             </span>
             <span className="flex items-center gap-1.5">
               <Shield className="w-3.5 h-3.5 text-[#ff6a1a]" />

--- a/lib/fred-brain.ts
+++ b/lib/fred-brain.ts
@@ -183,7 +183,7 @@ export const FRED_COMPANIES = {
     tvHouseholdsReach: "75% worldwide",
     annualRevenue: "$700M+ (Imagine Communications)",
     customerRevenueGenerated: "$50B",
-    capitalRaised: "$1B+",
+    capitalRaised: "$3B+",
     ideaprosRevenue: "$30M+",
   },
 } as const;
@@ -398,7 +398,7 @@ export const SAHARA_MESSAGING = {
 // ============================================================================
 
 export const MARKETING_STATS = {
-  capitalRaised: "$1B+",
+  capitalRaised: "$3B+",
   foundersCoached: "Hundreds",
   yearsExperience: "50+",
   companiesAdvised: "Hundreds",

--- a/workers/voice-agent/dist/lib/agents/fred-agent-voice.js
+++ b/workers/voice-agent/dist/lib/agents/fred-agent-voice.js
@@ -13,7 +13,7 @@ import { FRED_COMMUNICATION_STYLE, FRED_BIO, } from '@/lib/fred-brain';
  * NOT the full system prompt -- just enough voice identity
  * for structured output tools to adopt Fred's style.
  */
-export const FRED_AGENT_VOICE = `You are Fred Cary -- serial entrepreneur with ${FRED_BIO.yearsExperience}+ years of experience, ${FRED_BIO.companiesFounded}+ companies founded, ${FRED_BIO.ipos} IPOs, and over 10,000 founders coached.
+export const FRED_AGENT_VOICE = `You are Fred Cary -- serial entrepreneur with ${FRED_BIO.yearsExperience}+ years of experience, ${FRED_BIO.companiesFounded}+ companies founded, ${FRED_BIO.ipos} IPOs, and hundreds of founders coached.
 
 Voice: ${FRED_COMMUNICATION_STYLE.voice.primary}. ${FRED_COMMUNICATION_STYLE.voice.tone}.
 

--- a/workers/voice-agent/dist/lib/fred-brain.d.ts
+++ b/workers/voice-agent/dist/lib/fred-brain.d.ts
@@ -210,11 +210,11 @@ export declare const SAHARA_MESSAGING: {
     readonly vision: "What if you could create a unicorn, all by yourself?";
     readonly positioning: "Your AI-powered co-founder, available 24/7";
     readonly valueProps: readonly ["Think Clearer - Get clarity on your strategy", "Raise Smarter - Prepare for investors the right way", "Scale Faster - Execute with proven frameworks"];
-    readonly differentiators: readonly ["24/7 proactive guidance (not reactive)", "Real-time strategy and execution support", "Based on 50+ years and 10,000+ founder coaching sessions", "Acts as co-founder, not just advisor"];
+    readonly differentiators: readonly ["24/7 proactive guidance (not reactive)", "Real-time strategy and execution support", "Based on 50+ years and hundreds of founder coaching sessions", "Acts as co-founder, not just advisor"];
 };
 export declare const MARKETING_STATS: {
-    readonly capitalRaised: "$100M+";
-    readonly foundersCoached: "10,000+";
+    readonly capitalRaised: "$3B+";
+    readonly foundersCoached: "Hundreds";
     readonly yearsExperience: "50+";
     readonly companiesFounded: "40+";
     readonly startupsLaunched: "300+";

--- a/workers/voice-agent/dist/lib/fred-brain.js
+++ b/workers/voice-agent/dist/lib/fred-brain.js
@@ -357,7 +357,7 @@ export const SAHARA_MESSAGING = {
     differentiators: [
         "24/7 proactive guidance (not reactive)",
         "Real-time strategy and execution support",
-        "Based on 50+ years and 10,000+ founder coaching sessions",
+        "Based on 50+ years and hundreds of founder coaching sessions",
         "Acts as co-founder, not just advisor",
     ],
 };
@@ -365,8 +365,8 @@ export const SAHARA_MESSAGING = {
 // MARKETING STATS (Single source of truth for all marketing copy)
 // ============================================================================
 export const MARKETING_STATS = {
-    capitalRaised: "$100M+",
-    foundersCoached: "10,000+",
+    capitalRaised: "$3B+",
+    foundersCoached: "Hundreds",
     yearsExperience: "50+",
     companiesFounded: "40+",
     startupsLaunched: "300+",
@@ -381,7 +381,7 @@ export function getRandomQuote() {
     return quotes[Math.floor(Math.random() * quotes.length)];
 }
 export function getExperienceStatement() {
-    return `With over ${FRED_BIO.yearsExperience} years of experience, having founded ${FRED_BIO.companiesFounded}+ companies, and coaching 10,000+ founders, I've seen what works and what doesn't.`;
+    return `With over ${FRED_BIO.yearsExperience} years of experience, having founded ${FRED_BIO.companiesFounded}+ companies, and coaching hundreds of founders, I've seen what works and what doesn't.`;
 }
 export function getCredibilityStatement() {
     return `I've taken 3 companies public, had 2 acquired, created technology used in 75% of the world's TV households, and helped generate over $50 billion in revenue for my customers.`;

--- a/workers/voice-agent/dist/lib/voice-agent.js
+++ b/workers/voice-agent/dist/lib/voice-agent.js
@@ -295,7 +295,7 @@ Your role on this call:
 About you:
 - Founded ${FRED_BIO.companiesFounded}+ companies, taken ${FRED_BIO.ipos} public, had ${FRED_BIO.acquisitions} acquired
 - Created technology used in ${FRED_COMPANIES.summaryStats.tvHouseholdsReach} of the world's TV households
-- Coached 10,000+ founders through IdeaPros and now Sahara
+- Coached hundreds of founders through IdeaPros and now Sahara
 - Your motto: ${FRED_COMMUNICATION_STYLE.voice.primary}
 
 About Sahara (your current venture):

--- a/workers/voice-agent/dist/workers/voice-agent/agent.js
+++ b/workers/voice-agent/dist/workers/voice-agent/agent.js
@@ -19,7 +19,7 @@ Your role on this call:
 About you:
 - Founded ${FRED_BIO.companiesFounded}+ companies, taken ${FRED_BIO.ipos} public, had ${FRED_BIO.acquisitions} acquired
 - Created technology used in ${FRED_COMPANIES.summaryStats.tvHouseholdsReach} of the world's TV households
-- Coached 10,000+ founders through IdeaPros and now Sahara
+- Coached hundreds of founders through IdeaPros and now Sahara
 - Your motto: ${FRED_COMMUNICATION_STYLE.voice.primary}
 
 About Sahara (your current venture):


### PR DESCRIPTION
## Summary
- Updated fundraising figures from `$1B+` to `$3B+` across all landing pages, metadata, voice agent prompts, and the fred-brain knowledge base
- Removed all 9 unverified/fabricated testimonials (Sarah Chen, Marcus Rodriguez, etc.) from the testimonials section, keeping only the factual social proof banner
- Fixed `10,000+ founders coached` to `hundreds of founders coached` in voice agent dist files

## Files changed (14)
- `lib/fred-brain.ts` — MARKETING_STATS and FRED_COMPANIES capitalRaised
- `components/hero.tsx`, `components/stats.tsx`, `components/footer.tsx` — landing page stats
- `components/testimonials.tsx` — removed fake testimonials, kept social proof banner
- `app/layout.tsx` — meta description
- `app/about/page.tsx`, `app/deck/deck-content.tsx` — about page and pitch deck stats
- `funnel/src/pages/LandingPage.tsx` — funnel trust badges
- `workers/voice-agent/dist/` — 5 compiled voice agent files with stale data

## Test plan
- [ ] Verify landing page hero shows `$3B+ Raised`
- [ ] Verify stats section animates to `$3B+`
- [ ] Verify testimonials section shows only the social proof banner (no individual testimonial cards)
- [ ] Verify footer shows `$3B+ raised`
- [ ] Verify `/about` page shows `$3B+` Capital Raised stat

🤖 Generated with [Claude Code](https://claude.com/claude-code)