### PR TITLE
AI-914: fix: demo page No account required copy mismatch

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -60,7 +60,7 @@ export default function DemoPage() {
             </h1>
             <p className="text-xl text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
               Explore interactive demos of Sahara&apos;s AI-powered tools for founders.
-              Free account required to analyze your startup.
+              No account required.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- Changed demo page subtitle from "Free account required to analyze your startup" to "No account required"
- The demo pages use mock/sample data and don't require any account signup, so the old copy was misleading

## Test plan
- [x] `next build` passes
- [ ] Visual check: navigate to /demo and confirm copy reads "No account required"

🤖 Generated with [Claude Code](https://claude.com/claude-code)