### PR TITLE
AI-914: fix demo page No account required copy mismatch

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -60,7 +60,7 @@ export default function DemoPage() {
             </h1>
             <p className="text-xl text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
               Explore interactive demos of Sahara&apos;s AI-powered tools for founders.
-              No account required.
+              Sign up free to unlock full analysis.
             </p>
           </div>
 

--- a/app/demo/reality-lens/page.tsx
+++ b/app/demo/reality-lens/page.tsx
@@ -224,8 +224,8 @@ export default function RealityLensDemo() {
               </div>
 
               <Button asChild size="lg" className="w-full bg-[#ff6a1a] hover:bg-[#ea580c] text-white shadow-lg shadow-[#ff6a1a]/25 mt-8">
-                <Link href="/chat">
-                  Sign Up Free & Analyze <ArrowRight className="ml-2 w-4 h-4" />
+                <Link href="/get-started">
+                  Get Started Free <ArrowRight className="ml-2 w-4 h-4" />
                 </Link>
               </Button>
             </motion.div>


### PR DESCRIPTION
Closes AI-914

## Summary
- **`/demo` page**: Replaced misleading "No account required." with "Sign up free to unlock full analysis." to set correct expectations
- **`/demo/reality-lens` page**: Changed CTA link from `/chat` (protected route, redirects to sign-in) to `/get-started` (public route), consistent with all other demo page CTAs (boardy, pitch-deck, virtual-team)
- Updated button text from "Sign Up Free & Analyze" to "Get Started Free"

## Root Cause
`/chat` is listed in `DEFAULT_PROTECTED_ROUTES` in `lib/auth/middleware-utils.ts`, so clicking the CTA on `/demo/reality-lens` would redirect unauthenticated users to the login page, contradicting the "No account required" promise on `/demo`.

## Testing
- TypeScript compiles clean (no errors in changed files)
- Verified `/get-started` is in `DEFAULT_PUBLIC_ROUTES` (no auth wall)
- All other demo pages already use `/get-started` as their CTA target

Linear: https://linear.app/ai-acrobatics/issue/AI-914/fix-demo-page-no-account-required-copy-mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)