### PR TITLE
AI-838: fix stale comment — execute actor no longer returns void

### DIFF
--- a/lib/fred/machine.ts
+++ b/lib/fred/machine.ts
@@ -77,8 +77,8 @@ function createInitialContext(
 
 function buildSimpleDecision(input: ValidatedInput): DecisionResult {
   // Generate actual response content inline (no placeholders).
-  // The execute actor returns void and doesn't update context.decision,
-  // so streaming reads context.decision.content directly.
+  // The execute actor's onDone handler merges event.output back into
+  // context.decision, so streaming reads context.decision.content directly.
   let content: string;
   if (input.intent === "greeting") {
     const greetings = [


### PR DESCRIPTION
Closes AI-838

## Summary
The core code fix for AI-838 (execute actor typed as void, discarded enriched FredResponse) was already applied in commit fc47696. All four aspects are confirmed present:

1. `fromPromise<FredResponse>` — correctly typed
2. `return await executeActor(...)` — response propagates  
3. `onDone` handler merges `event.output.content` and `metadata` back into `context.decision`
4. `fastPath` guard — reuses existing content instead of generating new random greeting

This PR fixes a **stale comment** in `buildSimpleDecision()` that still said "The execute actor returns void and doesn't update context.decision" — which is no longer true after the fix.

## Changes
- Updated comment in `lib/fred/machine.ts` `buildSimpleDecision()` to reflect the current behavior

## Testing
- Comment-only change; no runtime behavior affected
- Verified pre-existing TS errors are unrelated (from AI-839 tier-badge work)

Linear: https://linear.app/ai-acrobatics/issue/AI-838/fixfred-machine-execute-actor-typed-as-void-discarded-enriched