### PR TITLE
[Pipeline] Create missing whatsapp_monitor_state DB table

### DIFF
--- a/supabase/migrations/20260407000002_create_whatsapp_monitor_state.sql
+++ b/supabase/migrations/20260407000002_create_whatsapp_monitor_state.sql
@@ -1,0 +1,33 @@
+-- Create whatsapp_monitor_state table for Trigger.dev WhatsApp monitor
+-- Tracks last check timestamp per group to avoid duplicate message processing
+-- Referenced by: trigger/sahara-whatsapp-monitor.ts
+
+CREATE TABLE IF NOT EXISTS whatsapp_monitor_state (
+  group_name    TEXT PRIMARY KEY,
+  last_check_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  context_id    TEXT,
+  error_count   INTEGER NOT NULL DEFAULT 0,
+  last_error    TEXT,
+  last_error_at TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Enable RLS (service role only — no client access needed)
+ALTER TABLE whatsapp_monitor_state ENABLE ROW LEVEL SECURITY;
+
+-- Auto-update updated_at on changes
+CREATE OR REPLACE FUNCTION update_whatsapp_monitor_state_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER whatsapp_monitor_state_updated_at
+  BEFORE UPDATE ON whatsapp_monitor_state
+  FOR EACH ROW
+  EXECUTE FUNCTION update_whatsapp_monitor_state_updated_at();
+
+COMMENT ON TABLE whatsapp_monitor_state IS 'Tracks WhatsApp monitor state per group for the Trigger.dev scheduled task';


### PR DESCRIPTION
## Summary
- Created Supabase migration for the `whatsapp_monitor_state` table referenced by `trigger/sahara-whatsapp-monitor.ts`
- Without this table, the WhatsApp monitor has never run successfully in production
- Columns: `group_name` (PK), `last_check_at`, `context_id`, `error_count`, `last_error`, `last_error_at`
- RLS enabled, auto-updating `updated_at` trigger

## Verification
- Run `supabase db push` to apply the migration to Supabase prod
- Verify the trigger task can upsert/read from the table

## Note
Supersedes PR #131 which had this migration mixed with unrelated changes. This PR is focused on the migration only.

Linear: AI-4105

🤖 Generated with [Claude Code](https://claude.com/claude-code)