### PR TITLE
fix: add Linear label/project/cycle assignment to issue creation

### DIFF
--- a/lib/feedback/linear-auto-triage.ts
+++ b/lib/feedback/linear-auto-triage.ts
@@ -13,6 +13,7 @@ import { createServiceClient } from "@/lib/supabase/server"
 // ── Constants ───────────────────────────────────────────────────
 
 const LINEAR_TEAM = "Ai Acrobatics"
+const LINEAR_PROJECT = "Sahara - AI Founder OS"
 const ADMIN_DASHBOARD_URL = process.env.NEXT_PUBLIC_APP_URL
   ? `${process.env.NEXT_PUBLIC_APP_URL}/admin/feedback`
   : "https://joinsahara.com/admin/feedback"
@@ -68,7 +69,7 @@ export async function createLinearIssueFromInsight(
   }
 
   try {
-    // Step 1: Get team ID
+    // Step 1: Get team ID, active cycle, project ID, and label IDs
     const teamQuery = await fetch("https://api.linear.app/graphql", {
       method: "POST",
       headers: {
@@ -76,7 +77,17 @@ export async function createLinearIssueFromInsight(
         Authorization: apiKey,
       },
       body: JSON.stringify({
-        query: `query { teams(filter: { name: { eq: "${LINEAR_TEAM}" } }) { nodes { id } } }`,
+        query: `query {
+          teams(filter: { name: { eq: "${LINEAR_TEAM}" } }) {
+            nodes { id activeCycle { id } }
+          }
+          projects(filter: { name: { eq: "${LINEAR_PROJECT}" } }) {
+            nodes { id }
+          }
+          issueLabels(filter: { name: { in: ["Bug", "Feature", "Improvement"] } }) {
+            nodes { id name }
+          }
+        }`,
       }),
     })
 
@@ -85,6 +96,10 @@ export async function createLinearIssueFromInsight(
     if (!teamId) {
       return { success: false, error: `Team "${LINEAR_TEAM}" not found in Linear` }
     }
+
+    const cycleId = teamData.data?.teams?.nodes?.[0]?.activeCycle?.id
+    const projectId = teamData.data?.projects?.nodes?.[0]?.id
+    const allLabels: { id: string; name: string }[] = teamData.data?.issueLabels?.nodes || []
 
     // Step 2: Build description
     const signalIdsList = insight.signal_ids.slice(0, 20)
@@ -116,8 +131,14 @@ Auto-created from feedback pattern detection.
 ### Signal IDs
 ${signalIdsFormatted}${truncation}`
 
-    // Step 3: Create issue
+    // Step 3: Create issue with labels, project, and cycle
     const priority = severityToPriority(insight.severity)
+
+    // Map feedback category to label — default to "Improvement" for feedback clusters
+    const labelName = insight.category === "bug" ? "Bug" : insight.category === "feature_request" ? "Feature" : "Improvement"
+    const labelIds = allLabels
+      .filter((l) => l.name === labelName)
+      .map((l) => l.id)
 
     const createRes = await fetch("https://api.linear.app/graphql", {
       method: "POST",
@@ -138,6 +159,9 @@ ${signalIdsFormatted}${truncation}`
             title: `[Feedback] ${insight.title}`,
             description,
             priority,
+            labelIds,
+            ...(projectId && { projectId }),
+            ...(cycleId && { cycleId }),
           },
         },
       }),

--- a/trigger/sahara-whatsapp-monitor.ts
+++ b/trigger/sahara-whatsapp-monitor.ts
@@ -346,7 +346,7 @@ async function createLinearIssue(issue: IdentifiedIssue): Promise<string> {
     throw new Error("LINEAR_API_KEY not configured");
   }
 
-  // Get team ID first
+  // Get team ID, label IDs, project ID, and active cycle in one query
   const teamQuery = await fetch("https://api.linear.app/graphql", {
     method: "POST",
     headers: {
@@ -354,7 +354,17 @@ async function createLinearIssue(issue: IdentifiedIssue): Promise<string> {
       Authorization: apiKey,
     },
     body: JSON.stringify({
-      query: `query { teams(filter: { name: { eq: "${LINEAR_TEAM}" } }) { nodes { id } } }`,
+      query: `query {
+        teams(filter: { name: { eq: "${LINEAR_TEAM}" } }) {
+          nodes { id activeCycle { id } }
+        }
+        issueLabels(filter: { name: { in: ["Bug", "Feature", "Improvement"] } }) {
+          nodes { id name }
+        }
+        projects(filter: { name: { eq: "${LINEAR_PROJECT}" } }) {
+          nodes { id }
+        }
+      }`,
     }),
   });
 
@@ -362,9 +372,17 @@ async function createLinearIssue(issue: IdentifiedIssue): Promise<string> {
   const teamId = teamData.data?.teams?.nodes?.[0]?.id;
   if (!teamId) throw new Error(`Team "${LINEAR_TEAM}" not found`);
 
-  // Create the issue
-  const labels = issue.type === "bug" ? ["Bug"] : issue.type === "feature" ? ["Feature"] : ["Improvement"];
+  const cycleId = teamData.data?.teams?.nodes?.[0]?.activeCycle?.id;
+  const projectId = teamData.data?.projects?.nodes?.[0]?.id;
 
+  // Resolve label IDs by issue type
+  const labelName = issue.type === "bug" ? "Bug" : issue.type === "feature" ? "Feature" : "Improvement";
+  const allLabels: { id: string; name: string }[] = teamData.data?.issueLabels?.nodes || [];
+  const labelIds = allLabels
+    .filter((l) => l.name === labelName)
+    .map((l) => l.id);
+
+  // Create the issue with labels, project, and cycle
   const createRes = await fetch("https://api.linear.app/graphql", {
     method: "POST",
     headers: {
@@ -384,7 +402,9 @@ async function createLinearIssue(issue: IdentifiedIssue): Promise<string> {
           title: issue.title,
           description: `## Source\nWhatsApp Feedback — Sahara Founders group (auto-detected)\n\n## Description\n${issue.description}\n\n## Original Message\n> ${issue.source_message}`,
           priority: issue.priority,
-          labelIds: [], // Labels need IDs, skip for now
+          labelIds,
+          ...(projectId && { projectId }),
+          ...(cycleId && { cycleId }),
         },
       },
     }),


### PR DESCRIPTION
## Summary
- Fixed WhatsApp monitor (`trigger/sahara-whatsapp-monitor.ts`) to assign Bug/Feature/Improvement labels, Sahara project, and active cycle when creating Linear issues
- Fixed feedback auto-triage (`lib/feedback/linear-auto-triage.ts`) with the same label/project/cycle assignment
- Both now fetch label IDs, project ID, and active cycle ID dynamically from the Linear API in a single query

## Changes
- **`trigger/sahara-whatsapp-monitor.ts`**: Expanded team query to also fetch `activeCycle`, project ID, and label IDs. Replaced hardcoded `labelIds: []` with resolved IDs based on issue type. Added `projectId` and `cycleId` to issue creation input.
- **`lib/feedback/linear-auto-triage.ts`**: Same pattern — extended the initial query, added label resolution by category, and included project/cycle in issue creation.

## Verification
- TypeScript compiles cleanly (no errors in changed files)
- Labels are resolved dynamically by name (Bug/Feature/Improvement) so no hardcoded IDs
- Project and cycle are fetched at runtime, so they stay current as cycles rotate

Linear: AI-4114

🤖 Generated with [Claude Code](https://claude.com/claude-code)