### PR TITLE
[Pipeline] Send resolution notifications to WhatsApp

### DIFF
--- a/app/api/webhooks/linear/route.ts
+++ b/app/api/webhooks/linear/route.ts
@@ -1,0 +1,163 @@
+/**
+ * Linear Webhook — Issue State Change Handler
+ *
+ * Receives webhook events from Linear when issues change state.
+ * When a Sahara project issue moves to "Done"/"Completed", sends a
+ * resolution notification to the "Sahara Founders" WhatsApp group.
+ *
+ * POST /api/webhooks/linear
+ *
+ * Setup: In Linear → Settings → API → Webhooks → Create webhook
+ *   URL: https://joinsahara.com/api/webhooks/linear
+ *   Events: "Issues" (state changes)
+ *   Secret: Set LINEAR_WEBHOOK_SECRET env var
+ *
+ * Linear: AI-4113
+ */
+
+import { NextRequest, NextResponse } from "next/server"
+import { createHmac } from "crypto"
+import { sendResolutionNotification } from "@/lib/feedback/whatsapp-reply"
+import { createClient } from "@supabase/supabase-js"
+
+export const dynamic = "force-dynamic"
+
+const LOG_PREFIX = "[Webhook: Linear]"
+const WHATSAPP_GROUP_NAME = "Sahara Founders"
+const SAHARA_PROJECT_NAME = "Sahara - AI Founder OS"
+
+interface LinearWebhookPayload {
+  action: "create" | "update" | "remove"
+  type: "Issue" | "Comment" | "Project"
+  data: {
+    id: string
+    identifier: string
+    title: string
+    state?: { name: string; type: string }
+    project?: { id: string; name: string }
+    labelIds?: string[]
+    labels?: Array<{ id: string; name: string }>
+  }
+  updatedFrom?: {
+    stateId?: string
+    state?: { name: string; type: string }
+  }
+}
+
+function verifySignature(
+  body: string,
+  signature: string | null
+): boolean {
+  const secret = process.env.LINEAR_WEBHOOK_SECRET
+  if (!secret) {
+    // If no secret configured, skip verification (log warning)
+    console.warn(`${LOG_PREFIX} LINEAR_WEBHOOK_SECRET not set — skipping signature verification`)
+    return true
+  }
+  if (!signature) return false
+
+  const hmac = createHmac("sha256", secret)
+  hmac.update(body)
+  const expected = hmac.digest("hex")
+
+  return expected === signature
+}
+
+export async function POST(request: NextRequest) {
+  const rawBody = await request.text()
+  const signature = request.headers.get("linear-signature")
+
+  // Verify webhook signature
+  if (!verifySignature(rawBody, signature)) {
+    console.warn(`${LOG_PREFIX} Invalid signature`)
+    return NextResponse.json({ error: "Invalid signature" }, { status: 401 })
+  }
+
+  let payload: LinearWebhookPayload
+  try {
+    payload = JSON.parse(rawBody)
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  // Only handle issue updates
+  if (payload.type !== "Issue" || payload.action !== "update") {
+    return NextResponse.json({ ok: true, skipped: "not an issue update" })
+  }
+
+  const { data, updatedFrom } = payload
+
+  // Only handle state transitions to "completed" type
+  const isNowCompleted = data.state?.type === "completed"
+  const wasNotCompleted = updatedFrom?.stateId !== undefined // state changed
+  const wasCompletedBefore = updatedFrom?.state?.type === "completed"
+
+  if (!isNowCompleted || !wasNotCompleted || wasCompletedBefore) {
+    return NextResponse.json({ ok: true, skipped: "not a completion transition" })
+  }
+
+  // Filter to Sahara project only
+  if (data.project?.name && data.project.name !== SAHARA_PROJECT_NAME) {
+    return NextResponse.json({ ok: true, skipped: "not Sahara project" })
+  }
+
+  console.log(
+    `${LOG_PREFIX} Issue completed: ${data.identifier} — ${data.title}`
+  )
+
+  // Send WhatsApp resolution notification
+  const result = await sendResolutionNotification(
+    WHATSAPP_GROUP_NAME,
+    data.title,
+    data.identifier
+  )
+
+  if (!result.success) {
+    console.error(
+      `${LOG_PREFIX} WhatsApp notification failed: ${result.error}`
+    )
+  } else {
+    console.log(
+      `${LOG_PREFIX} WhatsApp notification sent for ${data.identifier}`
+    )
+  }
+
+  // Also update feedback_insights if this issue was created from feedback
+  try {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!
+    )
+
+    const { data: insight } = await supabase
+      .from("feedback_insights")
+      .select("id")
+      .eq("linear_issue_id", data.id)
+      .eq("status", "actioned")
+      .single()
+
+    if (insight) {
+      await supabase
+        .from("feedback_insights")
+        .update({
+          status: "resolved",
+          resolved_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq("id", insight.id)
+
+      console.log(
+        `${LOG_PREFIX} Feedback insight ${insight.id} marked resolved`
+      )
+    }
+  } catch {
+    // Non-critical — the cron fallback will catch this
+  }
+
+  return NextResponse.json({
+    ok: true,
+    issue: data.identifier,
+    title: data.title,
+    notified: result.success,
+  })
+}

--- a/lib/feedback/whatsapp-reply.ts
+++ b/lib/feedback/whatsapp-reply.ts
@@ -88,13 +88,14 @@ export async function sendFeedbackAck(
 }
 
 /**
- * Sends resolution notification when a Linear issue is closed
+ * Sends resolution notification when a Linear issue is closed.
+ * Posts to the WhatsApp group so founders know issues are addressed.
  */
 export async function sendResolutionNotification(
   groupName: string,
   issueTitle: string,
   issueIdentifier: string
-): Promise<void> {
-  const message = `Resolved: "${issueTitle}" (${issueIdentifier}) - Fixed and deployed.`;
-  await sendWhatsAppMessage(groupName, message);
+): Promise<{ success: boolean; error?: string }> {
+  const message = `✓ RESOLVED: ${issueTitle} — fixed and deployed (${issueIdentifier})`;
+  return sendWhatsAppMessage(groupName, message);
 }

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,10 @@
     {
       "path": "/api/cron/feedback-digest",
       "schedule": "0 9 * * 1"
+    },
+    {
+      "path": "/api/cron/sync-linear-status",
+      "schedule": "0 */4 * * *"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- Adds `POST /api/webhooks/linear` endpoint that receives Linear webhook events in real-time
- When a Sahara project issue transitions to "completed", sends `✓ RESOLVED: [title] — fixed and deployed` to the **Sahara Founders** WhatsApp group
- Updates `sendResolutionNotification` message format to match the spec
- Registers the existing `sync-linear-status` cron in `vercel.json` as a 4-hour polling fallback
- Webhook also auto-resolves `feedback_insights` rows when their linked Linear issue completes

## Setup Required After Merge
1. In Linear → Settings → API → Webhooks → Create webhook:
   - URL: `https://joinsahara.com/api/webhooks/linear`
   - Events: Issues
   - Copy the signing secret → set `LINEAR_WEBHOOK_SECRET` env var in Vercel

## Test Plan
- [ ] Deploy to preview, POST a mock webhook payload with `state.type: "completed"` and verify 200 response
- [ ] Set up Linear webhook and close a Sahara issue — confirm WhatsApp message appears in "Sahara Founders"
- [ ] Verify cron fallback: hit `/api/cron/sync-linear-status` with auth header and confirm it resolves completed issues

Linear: AI-4113

🤖 Generated with [Claude Code](https://claude.com/claude-code)