### PR TITLE
feat: add 'How To Use Sahara' button with Loom video modal

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -43,6 +43,7 @@ import { useTier } from "@/lib/context/tier-context";
 import { createClient } from "@/lib/supabase/client";
 import { FloatingChatWidget } from "@/components/chat/floating-chat-widget";
 import { CallFredModal } from "@/components/dashboard/call-fred-modal";
+import { HowToUseSaharaModal } from "@/components/dashboard/how-to-use-sahara-modal";
 import { MobileBottomNav } from "@/components/mobile/mobile-bottom-nav";
 import { PageTransition } from "@/components/animations/PageTransition";
 import { VoiceChatOverlay } from "@/components/chat/voice-chat-overlay";
@@ -221,6 +222,7 @@ function SidebarContent({
   tierColors,
   isTierLoading,
   onNavClick,
+  onHowToUse,
 }: {
   user: { name: string; email: string; tier: UserTier; stage: string | null };
   visibleNavItems: NavItem[];
@@ -229,6 +231,7 @@ function SidebarContent({
   tierColors: string[];
   isTierLoading?: boolean;
   onNavClick?: () => void;
+  onHowToUse?: () => void;
 }) {
   return (
     <div className="flex flex-col h-full bg-white dark:bg-gray-950 border-r border-gray-200 dark:border-gray-800">
@@ -311,7 +314,7 @@ function SidebarContent({
       </nav>
 
       {/* Chat with Mentor -- prominent orange CTA */}
-      <div className="px-4 pt-2 pb-1 border-t border-gray-200 dark:border-gray-800">
+      <div className="px-4 pt-2 pb-1 border-t border-gray-200 dark:border-gray-800 space-y-2">
         <button
           onClick={() => openFredChat("Give me a tour of the platform and explain what each section does so I know where to go for what.")}
           className={cn(
@@ -322,6 +325,17 @@ function SidebarContent({
         >
           <MessageSquare className="h-4 w-4 shrink-0" />
           <span>Chat with Mentor</span>
+        </button>
+        <button
+          onClick={() => { onNavClick?.(); onHowToUse?.(); }}
+          className={cn(
+            "w-full flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg",
+            "border border-[#ff6a1a]/30 text-[#ff6a1a] hover:bg-[#ff6a1a]/10",
+            "font-medium transition-all duration-200 text-sm"
+          )}
+        >
+          <HelpCircle className="h-4 w-4 shrink-0" />
+          <span>How To Use Sahara</span>
         </button>
       </div>
 
@@ -348,10 +362,12 @@ export default function DashboardLayout({
   const [isAuthChecking, setIsAuthChecking] = useState(true);
   const [callModalOpen, setCallModalOpen] = useState(false);
   const [voiceOverlayOpen, setVoiceOverlayOpen] = useState(false);
+  const [howToUseOpen, setHowToUseOpen] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
   const { tier, isLoading: isTierLoading, refresh: refreshTier } = useTier();
   const handleCallFred = useCallback(() => setCallModalOpen(true), []);
+  const handleHowToUse = useCallback(() => setHowToUseOpen(true), []);
 
   // Listen for fred:voice custom event from MobileBottomNav
   useEffect(() => {
@@ -473,6 +489,7 @@ export default function DashboardLayout({
               tierColors={tierColors}
               isTierLoading={isTierLoading}
               onNavClick={closeSidebar}
+              onHowToUse={handleHowToUse}
             />
           </SheetContent>
         </Sheet>
@@ -486,6 +503,7 @@ export default function DashboardLayout({
             tierNames={tierNames}
             tierColors={tierColors}
             isTierLoading={isTierLoading}
+            onHowToUse={handleHowToUse}
           />
         </aside>
 
@@ -507,6 +525,9 @@ export default function DashboardLayout({
 
       {/* Phase 42: Call Fred Modal — Pro+ only */}
       <CallFredModal open={callModalOpen} onOpenChange={setCallModalOpen} />
+
+      {/* AI-4104: How To Use Sahara — Loom walkthrough video */}
+      <HowToUseSaharaModal open={howToUseOpen} onOpenChange={setHowToUseOpen} />
 
       {/* Voice Chat Overlay — available from mobile bottom nav and dashboard voice buttons */}
       <VoiceChatOverlay

--- a/components/dashboard/how-to-use-sahara-modal.tsx
+++ b/components/dashboard/how-to-use-sahara-modal.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog"
+
+/**
+ * Loom embed URL for the "How To Use Sahara" walkthrough video.
+ * Replace the video ID below once the actual Loom recording is created.
+ */
+const LOOM_VIDEO_ID = "placeholder"
+const LOOM_EMBED_URL = `https://www.loom.com/embed/${LOOM_VIDEO_ID}`
+
+interface HowToUseSaharaModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function HowToUseSaharaModal({
+  open,
+  onOpenChange,
+}: HowToUseSaharaModalProps) {
+  const isPlaceholder = LOOM_VIDEO_ID === "placeholder"
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-3xl p-0 overflow-hidden">
+        <DialogHeader className="p-6 pb-0">
+          <DialogTitle>How To Use Sahara</DialogTitle>
+          <DialogDescription>
+            Watch this walkthrough to learn how to get the most out of Sahara.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="px-6 pb-6">
+          {isPlaceholder ? (
+            <div className="aspect-video bg-gray-100 dark:bg-gray-800 rounded-lg flex flex-col items-center justify-center text-center p-8 gap-3">
+              <div className="text-4xl">🎬</div>
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Walkthrough video coming soon
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 max-w-md">
+                We&apos;re recording a comprehensive guide to help you navigate
+                Sahara. In the meantime, try chatting with your AI Mentor — just
+                click &quot;Chat with Mentor&quot; in the sidebar!
+              </p>
+            </div>
+          ) : (
+            <div className="aspect-video rounded-lg overflow-hidden">
+              <iframe
+                src={LOOM_EMBED_URL}
+                title="How To Use Sahara — Walkthrough"
+                frameBorder="0"
+                allowFullScreen
+                allow="autoplay; fullscreen; picture-in-picture"
+                className="w-full h-full"
+              />
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a **"How To Use Sahara"** button to the dashboard sidebar (below "Chat with Mentor")
- Opens a modal with an embedded Loom walkthrough video
- Currently shows a placeholder state until the actual Loom video is recorded — just swap `LOOM_VIDEO_ID` in `components/dashboard/how-to-use-sahara-modal.tsx`
- Button is orange-outlined to complement the existing orange "Chat with Mentor" CTA
- Available on both desktop sidebar and mobile hamburger drawer

## How to update with real video
1. Record the Loom walkthrough
2. Copy the Loom video ID from the share URL (e.g., `https://www.loom.com/share/abc123` → ID is `abc123`)
3. Update `LOOM_VIDEO_ID` in `components/dashboard/how-to-use-sahara-modal.tsx`

## Verification
- Open `/dashboard` → sidebar shows "How To Use Sahara" button
- Click it → modal opens with placeholder message
- Close modal → returns to dashboard
- Mobile: open hamburger menu → button is visible and functional

Linear: AI-4104

🤖 Generated with [Claude Code](https://claude.com/claude-code)