### PR TITLE
Reorder Reality Lens to first in sidebar navigation

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -151,6 +151,12 @@ const coreNavItems: NavItem[] = [
  */
 const conditionalNavItems: NavItem[] = [
   {
+    name: "Reality Lens",
+    href: "/dashboard/reality-lens",
+    icon: <ScanEye className="h-4 w-4" />,
+    condition: "showInvestorLens",
+  },
+  {
     name: "Positioning",
     href: "/dashboard/positioning",
     icon: <TargetIcon className="h-4 w-4" />,
@@ -185,12 +191,6 @@ const conditionalNavItems: NavItem[] = [
     href: "/dashboard/pitch-deck",
     icon: <Presentation className="h-4 w-4" />,
     condition: "showInvestorTools",
-  },
-  {
-    name: "Reality Lens",
-    href: "/dashboard/reality-lens",
-    icon: <ScanEye className="h-4 w-4" />,
-    condition: "showInvestorLens",
   },
   {
     name: "Virtual Team",


### PR DESCRIPTION
## Summary
- Moved "Reality Lens" from position 7 to position 1 in the conditional sidebar navigation items
- Per Fred Cary's WhatsApp feedback (March 20): "Actually, the Reality Lens should be first"

## Changes
- `app/dashboard/layout.tsx`: Reordered `conditionalNavItems` array — Reality Lens entry moved from after Pitch Deck to the top of the array

## Verification
- Reality Lens now appears first among conditional nav items for Pro+ users on non-early-stage startups
- No logic changes — only array order changed
- Pre-existing TS errors unrelated to this change (UserTier.BUILDER missing)

Linear: AI-4101

🤖 Generated with [Claude Code](https://claude.com/claude-code)