### PR TITLE
Phase 166: First Sale Experience

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -109,6 +109,11 @@ const coreNavItems: NavItem[] = [
     icon: <BookOpen className="h-4 w-4" />,
   },
   {
+    name: "Sales",
+    href: "/dashboard/sales",
+    icon: <TrendingUp className="h-4 w-4" />,
+  },
+  {
     name: "Marketplace",
     href: "/dashboard/marketplace",
     icon: <ShoppingBag className="h-4 w-4" />,

--- a/app/dashboard/sales/page.tsx
+++ b/app/dashboard/sales/page.tsx
@@ -1,0 +1,254 @@
+"use client"
+
+import { useState } from "react"
+import { motion } from "framer-motion"
+import {
+  Plus,
+  FileText,
+  Send,
+  CheckCircle2,
+  TrendingUp,
+  DollarSign,
+  BarChart3,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { QuoteCard } from "@/components/sales/quote-card"
+import { CommissionPanel } from "@/components/sales/commission-panel"
+import { CreateQuoteModal } from "@/components/sales/create-quote-modal"
+import { FirstSaleCelebration } from "@/components/sales/first-sale-celebration"
+import { SalesGuidedTour } from "@/components/sales/guided-tour"
+import { QuoteStatusBadge } from "@/components/sales/quote-status-badge"
+import {
+  DEMO_QUOTES,
+  DEMO_STATS,
+  MILESTONES,
+  calculateCommission,
+  PARTNER_SHARE_PERCENT,
+} from "@/lib/sales/demo-data"
+import type { QuoteStatus } from "@/types/sales"
+
+type FilterStatus = "all" | QuoteStatus
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+  }).format(amount)
+}
+
+export default function SalesDashboardPage() {
+  const [filter, setFilter] = useState<FilterStatus>("all")
+  const [isCreateOpen, setIsCreateOpen] = useState(false)
+
+  const filteredQuotes =
+    filter === "all"
+      ? DEMO_QUOTES
+      : DEMO_QUOTES.filter((q) => q.status === filter)
+
+  const firstSale = DEMO_QUOTES.find((q) => q.status === "accepted")
+  const firstSaleCommission = firstSale
+    ? calculateCommission(firstSale.amount)
+    : null
+
+  const statCards = [
+    {
+      label: "Total Quotes",
+      value: DEMO_STATS.totalQuotes,
+      icon: FileText,
+      color: "text-white",
+    },
+    {
+      label: "Active",
+      value: DEMO_STATS.activeQuotes,
+      icon: Send,
+      color: "text-blue-400",
+    },
+    {
+      label: "Accepted",
+      value: DEMO_STATS.acceptedQuotes,
+      icon: CheckCircle2,
+      color: "text-emerald-400",
+    },
+    {
+      label: "Conversion",
+      value: `${DEMO_STATS.conversionRate}%`,
+      icon: BarChart3,
+      color: "text-amber-400",
+    },
+  ]
+
+  const filterOptions: { label: string; value: FilterStatus }[] = [
+    { label: "All", value: "all" },
+    { label: "Draft", value: "draft" },
+    { label: "Sent", value: "sent" },
+    { label: "Accepted", value: "accepted" },
+    { label: "Expired", value: "expired" },
+  ]
+
+  return (
+    <>
+      {/* Guided Tour (shows on first visit) */}
+      <SalesGuidedTour />
+
+      {/* First Sale Celebration (shows once when first sale exists) */}
+      {firstSale && firstSaleCommission && (
+        <FirstSaleCelebration
+          clientName={firstSale.clientName}
+          amount={firstSale.amount}
+          commission={firstSaleCommission.partnerShare}
+        />
+      )}
+
+      <div className="min-h-screen p-4 md:p-6 lg:p-8 space-y-6">
+        {/* Page header */}
+        <div id="sales-overview" className="flex items-start justify-between">
+          <div>
+            <h1 className="text-2xl font-bold text-white">Sales</h1>
+            <p className="text-sm text-gray-400 mt-1">
+              Create quotes, track deals, and watch your earnings grow.
+            </p>
+          </div>
+          <Button
+            id="create-quote-btn"
+            onClick={() => setIsCreateOpen(true)}
+            className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white gap-2"
+          >
+            <Plus className="w-4 h-4" />
+            New Quote
+          </Button>
+        </div>
+
+        {/* Stats row */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          {statCards.map((stat, i) => {
+            const Icon = stat.icon
+            return (
+              <motion.div
+                key={stat.label}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: i * 0.05 }}
+                className="rounded-xl border border-white/10 bg-white/5 p-4"
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <Icon className={`w-4 h-4 ${stat.color}`} />
+                  <span className="text-xs text-gray-400 uppercase tracking-wide">
+                    {stat.label}
+                  </span>
+                </div>
+                <p className={`text-2xl font-bold ${stat.color}`}>
+                  {stat.value}
+                </p>
+              </motion.div>
+            )
+          })}
+        </div>
+
+        {/* Commission panel */}
+        <CommissionPanel quotes={DEMO_QUOTES} />
+
+        {/* Milestones */}
+        <div className="rounded-xl border border-white/10 bg-white/5 p-5">
+          <h3 className="text-sm font-medium text-gray-300 mb-4 flex items-center gap-2">
+            <TrendingUp className="w-4 h-4 text-[#ff6a1a]" />
+            Milestones
+          </h3>
+          <div className="flex items-center gap-4 overflow-x-auto pb-2">
+            {MILESTONES.map((milestone) => {
+              const achieved = !!milestone.achievedAt
+              return (
+                <div
+                  key={milestone.id}
+                  className={`flex-shrink-0 flex items-center gap-3 px-4 py-3 rounded-lg border ${
+                    achieved
+                      ? "border-emerald-500/20 bg-emerald-500/5"
+                      : "border-white/10 bg-white/5 opacity-50"
+                  }`}
+                >
+                  <div
+                    className={`w-8 h-8 rounded-full flex items-center justify-center ${
+                      achieved
+                        ? "bg-emerald-500/20 text-emerald-400"
+                        : "bg-gray-800 text-gray-500"
+                    }`}
+                  >
+                    {achieved ? (
+                      <CheckCircle2 className="w-4 h-4" />
+                    ) : (
+                      <DollarSign className="w-4 h-4" />
+                    )}
+                  </div>
+                  <div>
+                    <p
+                      className={`text-sm font-medium ${
+                        achieved ? "text-white" : "text-gray-500"
+                      }`}
+                    >
+                      {milestone.title}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {milestone.description}
+                    </p>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Quotes section */}
+        <div id="quote-list">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-sm font-medium text-gray-300">Your Quotes</h3>
+            <div className="flex items-center gap-1.5">
+              {filterOptions.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => setFilter(opt.value)}
+                  className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                    filter === opt.value
+                      ? "bg-[#ff6a1a]/20 text-[#ff6a1a]"
+                      : "text-gray-500 hover:text-gray-300"
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {filteredQuotes.length === 0 ? (
+            <div className="rounded-xl border border-white/10 bg-white/5 p-12 text-center">
+              <FileText className="w-8 h-8 text-gray-600 mx-auto mb-3" />
+              <p className="text-sm text-gray-400">
+                No {filter === "all" ? "" : filter} quotes yet
+              </p>
+              <Button
+                onClick={() => setIsCreateOpen(true)}
+                variant="outline"
+                size="sm"
+                className="mt-3 border-white/20 text-gray-300"
+              >
+                <Plus className="w-3 h-3 mr-1" />
+                Create your first quote
+              </Button>
+            </div>
+          ) : (
+            <div className="grid gap-3">
+              {filteredQuotes.map((quote, i) => (
+                <QuoteCard key={quote.id} quote={quote} index={i} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Create Quote Modal */}
+      <CreateQuoteModal
+        isOpen={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+      />
+    </>
+  )
+}

--- a/components/sales/commission-panel.tsx
+++ b/components/sales/commission-panel.tsx
@@ -1,0 +1,123 @@
+"use client"
+
+import { motion } from "framer-motion"
+import { DollarSign, TrendingUp, PieChart } from "lucide-react"
+import { calculateCommission, PARTNER_SHARE_PERCENT, PLATFORM_FEE_PERCENT } from "@/lib/sales/demo-data"
+import type { Quote } from "@/types/sales"
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
+export function CommissionPanel({ quotes }: { quotes: Quote[] }) {
+  const acceptedQuotes = quotes.filter((q) => q.status === "accepted")
+  const totalRevenue = acceptedQuotes.reduce((sum, q) => sum + q.amount, 0)
+  const totalCommission = totalRevenue * (PARTNER_SHARE_PERCENT / 100)
+  const pendingQuotes = quotes.filter((q) => q.status === "sent")
+  const pendingRevenue = pendingQuotes.reduce((sum, q) => sum + q.amount, 0)
+  const pendingCommission = pendingRevenue * (PARTNER_SHARE_PERCENT / 100)
+
+  return (
+    <div id="commission-panel" className="space-y-4">
+      {/* Earnings summary */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-4"
+        >
+          <div className="flex items-center gap-2 text-emerald-400 mb-1">
+            <DollarSign className="w-4 h-4" />
+            <span className="text-xs font-medium uppercase tracking-wide">
+              Your Earnings
+            </span>
+          </div>
+          <p className="text-2xl font-bold text-white">
+            {formatCurrency(totalCommission)}
+          </p>
+          <p className="text-xs text-gray-400 mt-1">
+            from {acceptedQuotes.length} accepted{" "}
+            {acceptedQuotes.length === 1 ? "quote" : "quotes"}
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.05 }}
+          className="rounded-xl border border-blue-500/20 bg-blue-500/5 p-4"
+        >
+          <div className="flex items-center gap-2 text-blue-400 mb-1">
+            <TrendingUp className="w-4 h-4" />
+            <span className="text-xs font-medium uppercase tracking-wide">
+              Pending
+            </span>
+          </div>
+          <p className="text-2xl font-bold text-white">
+            {formatCurrency(pendingCommission)}
+          </p>
+          <p className="text-xs text-gray-400 mt-1">
+            from {pendingQuotes.length} sent{" "}
+            {pendingQuotes.length === 1 ? "quote" : "quotes"}
+          </p>
+        </motion.div>
+
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 }}
+          className="rounded-xl border border-white/10 bg-white/5 p-4"
+        >
+          <div className="flex items-center gap-2 text-gray-400 mb-1">
+            <PieChart className="w-4 h-4" />
+            <span className="text-xs font-medium uppercase tracking-wide">
+              Your Split
+            </span>
+          </div>
+          <p className="text-2xl font-bold text-white">{PARTNER_SHARE_PERCENT}%</p>
+          <p className="text-xs text-gray-400 mt-1">
+            platform fee: {PLATFORM_FEE_PERCENT}%
+          </p>
+        </motion.div>
+      </div>
+
+      {/* Per-quote commission breakdown */}
+      {acceptedQuotes.length > 0 && (
+        <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+          <h4 className="text-sm font-medium text-gray-300 mb-3">
+            Commission Breakdown
+          </h4>
+          <div className="space-y-2">
+            {acceptedQuotes.map((quote) => {
+              const comm = calculateCommission(quote.amount)
+              return (
+                <div
+                  key={quote.id}
+                  className="flex items-center justify-between py-2 border-b border-white/5 last:border-0"
+                >
+                  <div>
+                    <p className="text-sm text-white">{quote.title}</p>
+                    <p className="text-xs text-gray-500">{quote.clientName}</p>
+                  </div>
+                  <div className="text-right">
+                    <p className="text-sm font-medium text-emerald-400">
+                      {formatCurrency(comm.partnerShare)}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      of {formatCurrency(comm.quoteAmount)}
+                    </p>
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/sales/create-quote-modal.tsx
+++ b/components/sales/create-quote-modal.tsx
@@ -1,0 +1,225 @@
+"use client"
+
+import { useState } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import { X, Plus, Trash2, Send, Save } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { calculateCommission } from "@/lib/sales/demo-data"
+
+interface LineItem {
+  description: string
+  quantity: number
+  unitPrice: number
+}
+
+interface CreateQuoteModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+  }).format(amount)
+}
+
+export function CreateQuoteModal({ isOpen, onClose }: CreateQuoteModalProps) {
+  const [clientName, setClientName] = useState("")
+  const [clientEmail, setClientEmail] = useState("")
+  const [title, setTitle] = useState("")
+  const [items, setItems] = useState<LineItem[]>([
+    { description: "", quantity: 1, unitPrice: 0 },
+  ])
+
+  const total = items.reduce((sum, item) => sum + item.quantity * item.unitPrice, 0)
+  const commission = calculateCommission(total)
+
+  const addItem = () => {
+    setItems([...items, { description: "", quantity: 1, unitPrice: 0 }])
+  }
+
+  const removeItem = (index: number) => {
+    if (items.length === 1) return
+    setItems(items.filter((_, i) => i !== index))
+  }
+
+  const updateItem = (index: number, field: keyof LineItem, value: string | number) => {
+    const updated = [...items]
+    updated[index] = { ...updated[index], [field]: value }
+    setItems(updated)
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50"
+            onClick={onClose}
+          />
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-2xl mx-4 max-h-[85vh] overflow-y-auto"
+          >
+            <div className="bg-gray-900 border border-white/10 rounded-2xl shadow-2xl">
+              {/* Header */}
+              <div className="flex items-center justify-between p-5 border-b border-white/10">
+                <h2 className="text-lg font-bold text-white">Create Quote</h2>
+                <button
+                  onClick={onClose}
+                  className="p-1.5 rounded-lg hover:bg-white/10 transition-colors"
+                >
+                  <X className="w-5 h-5 text-gray-400" />
+                </button>
+              </div>
+
+              {/* Form */}
+              <div className="p-5 space-y-5">
+                {/* Quote title */}
+                <div>
+                  <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                    Quote Title
+                  </label>
+                  <Input
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    placeholder="e.g. AI Strategy Consultation"
+                    className="bg-white/5 border-white/10 text-white placeholder:text-gray-600"
+                  />
+                </div>
+
+                {/* Client details */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                      Client Name
+                    </label>
+                    <Input
+                      value={clientName}
+                      onChange={(e) => setClientName(e.target.value)}
+                      placeholder="Marcus Chen"
+                      className="bg-white/5 border-white/10 text-white placeholder:text-gray-600"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-400 mb-1.5">
+                      Client Email
+                    </label>
+                    <Input
+                      value={clientEmail}
+                      onChange={(e) => setClientEmail(e.target.value)}
+                      placeholder="marcus@example.com"
+                      className="bg-white/5 border-white/10 text-white placeholder:text-gray-600"
+                    />
+                  </div>
+                </div>
+
+                {/* Line items */}
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <label className="text-xs font-medium text-gray-400">
+                      Line Items
+                    </label>
+                    <button
+                      onClick={addItem}
+                      className="flex items-center gap-1 text-xs text-[#ff6a1a] hover:text-[#ea580c] transition-colors"
+                    >
+                      <Plus className="w-3 h-3" />
+                      Add Item
+                    </button>
+                  </div>
+
+                  <div className="space-y-2">
+                    {items.map((item, i) => (
+                      <div key={i} className="flex items-center gap-2">
+                        <Input
+                          value={item.description}
+                          onChange={(e) =>
+                            updateItem(i, "description", e.target.value)
+                          }
+                          placeholder="Description"
+                          className="flex-1 bg-white/5 border-white/10 text-white placeholder:text-gray-600 text-sm"
+                        />
+                        <Input
+                          type="number"
+                          value={item.quantity || ""}
+                          onChange={(e) =>
+                            updateItem(i, "quantity", parseInt(e.target.value) || 0)
+                          }
+                          placeholder="Qty"
+                          className="w-16 bg-white/5 border-white/10 text-white text-sm text-center"
+                        />
+                        <Input
+                          type="number"
+                          value={item.unitPrice || ""}
+                          onChange={(e) =>
+                            updateItem(i, "unitPrice", parseFloat(e.target.value) || 0)
+                          }
+                          placeholder="Price"
+                          className="w-24 bg-white/5 border-white/10 text-white text-sm"
+                        />
+                        <button
+                          onClick={() => removeItem(i)}
+                          className="p-1.5 text-gray-500 hover:text-red-400 transition-colors"
+                          disabled={items.length === 1}
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Summary */}
+                <div className="rounded-xl bg-white/5 border border-white/10 p-4">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="text-sm text-gray-400">Total</span>
+                    <span className="text-lg font-bold text-white">
+                      {formatCurrency(total)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-gray-400">
+                      Your Commission (85%)
+                    </span>
+                    <span className="text-lg font-bold text-emerald-400">
+                      {formatCurrency(commission.partnerShare)}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Footer */}
+              <div className="flex items-center justify-end gap-3 p-5 border-t border-white/10">
+                <Button
+                  variant="outline"
+                  onClick={onClose}
+                  className="border-white/20 text-gray-300"
+                >
+                  <Save className="w-4 h-4 mr-2" />
+                  Save Draft
+                </Button>
+                <Button className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white">
+                  <Send className="w-4 h-4 mr-2" />
+                  Send Quote
+                </Button>
+              </div>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/components/sales/first-sale-celebration.tsx
+++ b/components/sales/first-sale-celebration.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import { Trophy, PartyPopper, Share2, ArrowRight } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+const FIRST_SALE_SEEN_KEY = "sahara_first_sale_celebrated"
+const AUTO_DISMISS_MS = 15_000
+
+function seededRandom(seed: number) {
+  const x = Math.sin(seed + 1) * 10000
+  return x - Math.floor(x)
+}
+
+function ConfettiPiece({ index }: { index: number }) {
+  const colors = ["#ff6a1a", "#f59e0b", "#10b981", "#6366f1", "#ec4899", "#14b8a6"]
+  const color = colors[index % colors.length]
+  const left = seededRandom(index * 7) * 100
+  const delay = seededRandom(index * 13) * 2
+  const duration = 2 + seededRandom(index * 17) * 2
+  const size = 6 + seededRandom(index * 23) * 8
+  const xDrift = (seededRandom(index * 31) - 0.5) * 200
+  const rotateTo = 360 + seededRandom(index * 37) * 360
+  const isRound = seededRandom(index * 41) > 0.5
+
+  return (
+    <motion.div
+      initial={{ y: -20, x: 0, opacity: 1, rotate: 0 }}
+      animate={{
+        y: [0, 600],
+        x: [0, xDrift],
+        opacity: [1, 1, 0],
+        rotate: [0, rotateTo],
+      }}
+      transition={{ duration, delay, ease: "easeIn" }}
+      className="absolute pointer-events-none"
+      style={{
+        left: `${left}%`,
+        top: -10,
+        width: size,
+        height: size * 1.5,
+        backgroundColor: color,
+        borderRadius: isRound ? "50%" : "2px",
+      }}
+    />
+  )
+}
+
+interface FirstSaleCelebrationProps {
+  clientName: string
+  amount: number
+  commission: number
+  onDismiss?: () => void
+}
+
+export function FirstSaleCelebration({
+  clientName,
+  amount,
+  commission,
+  onDismiss,
+}: FirstSaleCelebrationProps) {
+  const [isVisible, setIsVisible] = useState(false)
+
+  const dismiss = useCallback(() => {
+    setIsVisible(false)
+    localStorage.setItem(FIRST_SALE_SEEN_KEY, "true")
+    onDismiss?.()
+  }, [onDismiss])
+
+  useEffect(() => {
+    const seen = localStorage.getItem(FIRST_SALE_SEEN_KEY)
+    if (seen) return
+    setIsVisible(true)
+
+    const timer = setTimeout(dismiss, AUTO_DISMISS_MS)
+    return () => clearTimeout(timer)
+  }, [dismiss])
+
+  const formatCurrency = (n: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 0,
+    }).format(n)
+
+  return (
+    <AnimatePresence>
+      {isVisible && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.4 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+          onClick={dismiss}
+        >
+          {/* Confetti */}
+          <div className="absolute inset-0 overflow-hidden pointer-events-none">
+            {Array.from({ length: 60 }).map((_, i) => (
+              <ConfettiPiece key={i} index={i} />
+            ))}
+          </div>
+
+          {/* Celebration Card */}
+          <motion.div
+            initial={{ scale: 0.8, y: 40 }}
+            animate={{ scale: 1, y: 0 }}
+            exit={{ scale: 0.9, y: 20, opacity: 0 }}
+            transition={{ type: "spring", damping: 20, stiffness: 300 }}
+            className="relative z-10 max-w-lg w-full mx-4 p-8 rounded-2xl bg-gradient-to-br from-gray-900 to-gray-950 border border-[#ff6a1a]/30 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Glow */}
+            <div className="absolute -inset-px rounded-2xl bg-gradient-to-br from-[#ff6a1a]/20 via-amber-500/10 to-transparent pointer-events-none" />
+
+            <div className="relative text-center">
+              {/* Trophy icon */}
+              <motion.div
+                initial={{ scale: 0, rotate: -20 }}
+                animate={{ scale: 1, rotate: 0 }}
+                transition={{ type: "spring", delay: 0.2, damping: 10 }}
+                className="w-20 h-20 mx-auto mb-6 rounded-full bg-gradient-to-br from-[#ff6a1a] to-amber-500 flex items-center justify-center shadow-lg shadow-[#ff6a1a]/30"
+              >
+                <Trophy className="h-10 w-10 text-white" />
+              </motion.div>
+
+              {/* Heading */}
+              <motion.h2
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.3 }}
+                className="text-3xl font-bold text-white mb-2"
+              >
+                First Sale!
+              </motion.h2>
+
+              <motion.p
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.4 }}
+                className="text-lg text-amber-200 mb-1"
+              >
+                {clientName} accepted your quote
+              </motion.p>
+
+              {/* Revenue + Commission */}
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.5 }}
+                className="flex items-center justify-center gap-6 my-6"
+              >
+                <div>
+                  <p className="text-xs text-gray-400 uppercase tracking-wide">
+                    Deal Value
+                  </p>
+                  <p className="text-2xl font-bold text-white">
+                    {formatCurrency(amount)}
+                  </p>
+                </div>
+                <div className="w-px h-10 bg-white/10" />
+                <div>
+                  <p className="text-xs text-gray-400 uppercase tracking-wide">
+                    Your Commission
+                  </p>
+                  <p className="text-2xl font-bold text-emerald-400">
+                    {formatCurrency(commission)}
+                  </p>
+                </div>
+              </motion.div>
+
+              {/* FRED quote */}
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ delay: 0.6 }}
+                className="flex items-start gap-3 p-4 rounded-xl bg-white/5 border border-white/10 mb-6 text-left"
+              >
+                <PartyPopper className="w-5 h-5 text-[#ff6a1a] shrink-0 mt-0.5" />
+                <div>
+                  <p className="text-sm text-gray-300 italic">
+                    &ldquo;Your first sale is a milestone most never reach.
+                    This is where real momentum starts.&rdquo;
+                  </p>
+                  <p className="text-xs text-gray-500 mt-1">
+                    -- FRED, your AI mentor
+                  </p>
+                </div>
+              </motion.div>
+
+              {/* CTAs */}
+              <motion.div
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.7 }}
+                className="flex items-center justify-center gap-3"
+              >
+                <Button
+                  variant="outline"
+                  onClick={dismiss}
+                  className="border-white/20 text-gray-300 hover:text-white"
+                >
+                  <Share2 className="w-4 h-4 mr-2" />
+                  Share Milestone
+                </Button>
+                <Button
+                  onClick={dismiss}
+                  className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white"
+                >
+                  Keep Going
+                  <ArrowRight className="w-4 h-4 ml-2" />
+                </Button>
+              </motion.div>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/components/sales/guided-tour.tsx
+++ b/components/sales/guided-tour.tsx
@@ -1,0 +1,125 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { motion, AnimatePresence } from "framer-motion"
+import { ArrowRight, X, Sparkles } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { GUIDED_TOUR_STEPS } from "@/lib/sales/demo-data"
+
+const TOUR_SEEN_KEY = "sahara_sales_tour_seen"
+
+export function SalesGuidedTour() {
+  const [isActive, setIsActive] = useState(false)
+  const [currentStep, setCurrentStep] = useState(0)
+
+  useEffect(() => {
+    const seen = localStorage.getItem(TOUR_SEEN_KEY)
+    if (!seen) {
+      // Small delay so the page renders first
+      const timer = setTimeout(() => setIsActive(true), 800)
+      return () => clearTimeout(timer)
+    }
+  }, [])
+
+  const dismiss = useCallback(() => {
+    setIsActive(false)
+    localStorage.setItem(TOUR_SEEN_KEY, "true")
+  }, [])
+
+  const next = () => {
+    if (currentStep < GUIDED_TOUR_STEPS.length - 1) {
+      setCurrentStep(currentStep + 1)
+    } else {
+      dismiss()
+    }
+  }
+
+  if (!isActive) return null
+
+  const step = GUIDED_TOUR_STEPS[currentStep]
+  const isLast = currentStep === GUIDED_TOUR_STEPS.length - 1
+
+  return (
+    <AnimatePresence>
+      {isActive && (
+        <>
+          {/* Overlay */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40"
+            onClick={dismiss}
+          />
+
+          {/* Tooltip card */}
+          <motion.div
+            key={step.id}
+            initial={{ opacity: 0, y: 10, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full max-w-md mx-4"
+          >
+            <div className="bg-gray-900 border border-[#ff6a1a]/30 rounded-2xl p-6 shadow-2xl">
+              {/* Progress dots */}
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center gap-1.5">
+                  {GUIDED_TOUR_STEPS.map((_, idx) => (
+                    <div
+                      key={idx}
+                      className={`h-1.5 rounded-full transition-all duration-300 ${
+                        idx === currentStep
+                          ? "w-6 bg-[#ff6a1a]"
+                          : idx < currentStep
+                          ? "w-1.5 bg-[#ff6a1a]/50"
+                          : "w-1.5 bg-gray-700"
+                      }`}
+                    />
+                  ))}
+                </div>
+                <button
+                  onClick={dismiss}
+                  className="p-1 rounded-lg hover:bg-white/10 transition-colors"
+                >
+                  <X className="w-4 h-4 text-gray-400" />
+                </button>
+              </div>
+
+              {/* Icon */}
+              <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-[#ff6a1a] to-amber-500 flex items-center justify-center mb-4">
+                <Sparkles className="w-6 h-6 text-white" />
+              </div>
+
+              {/* Content */}
+              <h3 className="text-lg font-bold text-white mb-2">
+                {step.title}
+              </h3>
+              <p className="text-sm text-gray-400 leading-relaxed mb-6">
+                {step.description}
+              </p>
+
+              {/* Navigation */}
+              <div className="flex items-center justify-between">
+                <button
+                  onClick={dismiss}
+                  className="text-xs text-gray-500 hover:text-gray-300 transition-colors"
+                >
+                  Skip tour
+                </button>
+                <Button
+                  onClick={next}
+                  size="sm"
+                  className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white gap-1.5"
+                >
+                  {isLast ? "Start Selling" : "Next"}
+                  <ArrowRight className="w-3.5 h-3.5" />
+                </Button>
+              </div>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/components/sales/quote-card.tsx
+++ b/components/sales/quote-card.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { motion } from "framer-motion"
+import { User, Mail, DollarSign, Clock } from "lucide-react"
+import { QuoteStatusBadge } from "./quote-status-badge"
+import { QuoteTimeline } from "./quote-timeline"
+import { calculateCommission } from "@/lib/sales/demo-data"
+import type { Quote } from "@/types/sales"
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+  }).format(amount)
+}
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+export function QuoteCard({
+  quote,
+  index = 0,
+}: {
+  quote: Quote
+  index?: number
+}) {
+  const commission = calculateCommission(quote.amount)
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.05 }}
+      className="rounded-xl border border-white/10 bg-white/5 p-5 hover:border-white/20 transition-colors"
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base font-semibold text-white truncate">
+            {quote.title}
+          </h3>
+          <div className="flex items-center gap-3 mt-1">
+            <span className="flex items-center gap-1 text-xs text-gray-400">
+              <User className="w-3 h-3" />
+              {quote.clientName}
+            </span>
+            <span className="flex items-center gap-1 text-xs text-gray-500">
+              <Mail className="w-3 h-3" />
+              {quote.clientEmail}
+            </span>
+          </div>
+        </div>
+        <QuoteStatusBadge status={quote.status} />
+      </div>
+
+      {/* Amount + Commission */}
+      <div className="flex items-center gap-4 mb-4">
+        <div className="flex items-center gap-1.5">
+          <DollarSign className="w-4 h-4 text-white/50" />
+          <span className="text-lg font-bold text-white">
+            {formatCurrency(quote.amount)}
+          </span>
+        </div>
+        <div className="text-xs text-gray-500">|</div>
+        <div className="text-sm">
+          <span className="text-emerald-400 font-medium">
+            {formatCurrency(commission.partnerShare)}
+          </span>
+          <span className="text-gray-500 ml-1">commission</span>
+        </div>
+      </div>
+
+      {/* Line items */}
+      <div className="mb-4 space-y-1">
+        {quote.items.map((item) => (
+          <div
+            key={item.id}
+            className="flex items-center justify-between text-xs"
+          >
+            <span className="text-gray-400">{item.description}</span>
+            <span className="text-gray-300">
+              {item.quantity} x {formatCurrency(item.unitPrice)}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {/* Timeline */}
+      <div className="pt-3 border-t border-white/5">
+        <QuoteTimeline quote={quote} />
+      </div>
+
+      {/* Expiry notice for sent quotes */}
+      {quote.status === "sent" && quote.expiresAt && (
+        <div className="mt-3 flex items-center gap-1.5 text-xs text-amber-400/70">
+          <Clock className="w-3 h-3" />
+          Expires {formatDate(quote.expiresAt)}
+        </div>
+      )}
+    </motion.div>
+  )
+}

--- a/components/sales/quote-status-badge.tsx
+++ b/components/sales/quote-status-badge.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+import type { QuoteStatus } from "@/types/sales"
+
+const statusConfig: Record<
+  QuoteStatus,
+  { label: string; className: string; dot: string }
+> = {
+  draft: {
+    label: "Draft",
+    className: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+    dot: "bg-gray-400",
+  },
+  sent: {
+    label: "Sent",
+    className: "bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400",
+    dot: "bg-blue-500",
+  },
+  accepted: {
+    label: "Accepted",
+    className: "bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400",
+    dot: "bg-emerald-500",
+  },
+  expired: {
+    label: "Expired",
+    className: "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+    dot: "bg-red-400",
+  },
+}
+
+export function QuoteStatusBadge({ status }: { status: QuoteStatus }) {
+  const config = statusConfig[status]
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium",
+        config.className
+      )}
+    >
+      <span className={cn("w-1.5 h-1.5 rounded-full", config.dot)} />
+      {config.label}
+    </span>
+  )
+}

--- a/components/sales/quote-timeline.tsx
+++ b/components/sales/quote-timeline.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { motion } from "framer-motion"
+import { FileText, Send, CheckCircle2, Clock } from "lucide-react"
+import type { Quote } from "@/types/sales"
+
+function formatDate(dateStr?: string) {
+  if (!dateStr) return null
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
+const steps = [
+  { key: "created", label: "Created", icon: FileText, field: "createdAt" as const },
+  { key: "sent", label: "Sent", icon: Send, field: "sentAt" as const },
+  { key: "accepted", label: "Accepted", icon: CheckCircle2, field: "acceptedAt" as const },
+] as const
+
+export function QuoteTimeline({ quote }: { quote: Quote }) {
+  const isExpired = quote.status === "expired"
+
+  return (
+    <div className="flex items-center gap-2">
+      {steps.map((step, i) => {
+        const date = quote[step.field]
+        const isActive = !!date
+        const Icon = step.icon
+
+        return (
+          <div key={step.key} className="flex items-center gap-2">
+            {i > 0 && (
+              <div
+                className={`h-px w-6 ${
+                  isActive ? "bg-emerald-500/50" : "bg-gray-700"
+                }`}
+              />
+            )}
+            <motion.div
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ delay: i * 0.1 }}
+              className="flex items-center gap-1.5"
+            >
+              <div
+                className={`w-6 h-6 rounded-full flex items-center justify-center ${
+                  isActive
+                    ? "bg-emerald-500/20 text-emerald-400"
+                    : "bg-gray-800 text-gray-500"
+                }`}
+              >
+                <Icon className="w-3.5 h-3.5" />
+              </div>
+              <div className="text-xs">
+                <div
+                  className={
+                    isActive ? "text-gray-200 font-medium" : "text-gray-500"
+                  }
+                >
+                  {step.label}
+                </div>
+                {date && (
+                  <div className="text-gray-500 text-[10px]">
+                    {formatDate(date)}
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          </div>
+        )
+      })}
+
+      {/* Expiry indicator */}
+      {isExpired && (
+        <div className="flex items-center gap-2">
+          <div className="h-px w-6 bg-red-500/30" />
+          <div className="flex items-center gap-1.5">
+            <div className="w-6 h-6 rounded-full flex items-center justify-center bg-red-500/20 text-red-400">
+              <Clock className="w-3.5 h-3.5" />
+            </div>
+            <div className="text-xs">
+              <div className="text-red-400 font-medium">Expired</div>
+              <div className="text-gray-500 text-[10px]">
+                {formatDate(quote.expiresAt)}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/lib/sales/demo-data.ts
+++ b/lib/sales/demo-data.ts
@@ -1,0 +1,157 @@
+import type {
+  Quote,
+  SalesDashboardStats,
+  SalesMilestone,
+  CommissionBreakdown,
+  GuidedTourStep,
+} from "@/types/sales"
+
+// Platform commission structure
+export const PLATFORM_FEE_PERCENT = 15
+export const PARTNER_SHARE_PERCENT = 85
+
+export function calculateCommission(amount: number): CommissionBreakdown {
+  const platformFee = amount * (PLATFORM_FEE_PERCENT / 100)
+  const partnerShare = amount * (PARTNER_SHARE_PERCENT / 100)
+  return {
+    quoteAmount: amount,
+    platformFeePercent: PLATFORM_FEE_PERCENT,
+    platformFee,
+    partnerSharePercent: PARTNER_SHARE_PERCENT,
+    partnerShare,
+  }
+}
+
+export const DEMO_QUOTES: Quote[] = [
+  {
+    id: "q-001",
+    title: "AI Strategy Consultation",
+    clientName: "Marcus Chen",
+    clientEmail: "marcus@techventures.io",
+    amount: 4500,
+    status: "accepted",
+    createdAt: "2026-03-28T10:00:00Z",
+    sentAt: "2026-03-28T14:30:00Z",
+    acceptedAt: "2026-03-30T09:15:00Z",
+    expiresAt: "2026-04-28T10:00:00Z",
+    items: [
+      { id: "li-1", description: "AI Readiness Assessment", quantity: 1, unitPrice: 2000 },
+      { id: "li-2", description: "Strategy Workshop (2 sessions)", quantity: 2, unitPrice: 1250 },
+    ],
+  },
+  {
+    id: "q-002",
+    title: "Pitch Deck Review Package",
+    clientName: "Sarah Miller",
+    clientEmail: "sarah@bloom.co",
+    amount: 2000,
+    status: "sent",
+    createdAt: "2026-04-05T08:00:00Z",
+    sentAt: "2026-04-05T11:00:00Z",
+    expiresAt: "2026-05-05T08:00:00Z",
+    items: [
+      { id: "li-3", description: "Comprehensive Deck Review", quantity: 1, unitPrice: 1500 },
+      { id: "li-4", description: "Follow-up Coaching Call", quantity: 1, unitPrice: 500 },
+    ],
+  },
+  {
+    id: "q-003",
+    title: "Fundraising Bootcamp",
+    clientName: "James Park",
+    clientEmail: "james@parkstudios.com",
+    amount: 6000,
+    status: "draft",
+    createdAt: "2026-04-07T16:00:00Z",
+    expiresAt: "2026-05-07T16:00:00Z",
+    items: [
+      { id: "li-5", description: "4-Week Fundraising Program", quantity: 1, unitPrice: 5000 },
+      { id: "li-6", description: "Investor Intro Package", quantity: 1, unitPrice: 1000 },
+    ],
+  },
+  {
+    id: "q-004",
+    title: "Market Validation Sprint",
+    clientName: "Elena Vasquez",
+    clientEmail: "elena@newleaf.io",
+    amount: 3500,
+    status: "expired",
+    createdAt: "2026-02-15T09:00:00Z",
+    sentAt: "2026-02-15T12:00:00Z",
+    expiresAt: "2026-03-15T09:00:00Z",
+    items: [
+      { id: "li-7", description: "Market Analysis Report", quantity: 1, unitPrice: 2000 },
+      { id: "li-8", description: "Customer Discovery Coaching", quantity: 3, unitPrice: 500 },
+    ],
+  },
+]
+
+export const DEMO_STATS: SalesDashboardStats = {
+  totalQuotes: 4,
+  activeQuotes: 2,
+  acceptedQuotes: 1,
+  totalRevenue: 4500,
+  totalCommission: 4500 * (PARTNER_SHARE_PERCENT / 100),
+  conversionRate: 25,
+}
+
+export const MILESTONES: SalesMilestone[] = [
+  {
+    id: "ms-1",
+    type: "first_quote",
+    title: "First Quote Created",
+    description: "You created your first quote — the journey begins!",
+    achievedAt: "2026-02-15T09:00:00Z",
+  },
+  {
+    id: "ms-2",
+    type: "first_sent",
+    title: "First Quote Sent",
+    description: "You sent your first quote to a potential client.",
+    achievedAt: "2026-02-15T12:00:00Z",
+  },
+  {
+    id: "ms-3",
+    type: "first_sale",
+    title: "First Sale Closed!",
+    description: "Congratulations! You closed your first deal.",
+    achievedAt: "2026-03-30T09:15:00Z",
+  },
+  {
+    id: "ms-4",
+    type: "revenue_milestone",
+    title: "$10,000 Revenue",
+    description: "Hit your first $10K revenue milestone.",
+    threshold: 10000,
+  },
+]
+
+export const GUIDED_TOUR_STEPS: GuidedTourStep[] = [
+  {
+    id: "tour-1",
+    target: "sales-overview",
+    title: "Your Sales Dashboard",
+    description: "This is your command center. Track all your quotes, revenue, and commissions at a glance.",
+    placement: "bottom",
+  },
+  {
+    id: "tour-2",
+    target: "create-quote-btn",
+    title: "Create a Quote",
+    description: "Start by creating a quote for a potential client. Add line items, set pricing, and send it with one click.",
+    placement: "bottom",
+  },
+  {
+    id: "tour-3",
+    target: "quote-list",
+    title: "Track Your Quotes",
+    description: "Every quote shows its status — draft, sent, accepted, or expired. You always know where things stand.",
+    placement: "top",
+  },
+  {
+    id: "tour-4",
+    target: "commission-panel",
+    title: "Your Earnings",
+    description: "See your commission on every deal. You keep 85% of each sale — the platform takes just 15%.",
+    placement: "left",
+  },
+]

--- a/types/sales.ts
+++ b/types/sales.ts
@@ -1,0 +1,59 @@
+// Types for the First Sale Experience (Phase 166)
+
+export type QuoteStatus = "draft" | "sent" | "accepted" | "expired"
+
+export interface Quote {
+  id: string
+  title: string
+  clientName: string
+  clientEmail: string
+  amount: number
+  status: QuoteStatus
+  createdAt: string
+  sentAt?: string
+  acceptedAt?: string
+  expiresAt?: string
+  items: QuoteLineItem[]
+  notes?: string
+}
+
+export interface QuoteLineItem {
+  id: string
+  description: string
+  quantity: number
+  unitPrice: number
+}
+
+export interface CommissionBreakdown {
+  quoteAmount: number
+  platformFeePercent: number
+  platformFee: number
+  partnerSharePercent: number
+  partnerShare: number
+}
+
+export interface SalesMilestone {
+  id: string
+  type: "first_quote" | "first_sent" | "first_sale" | "revenue_milestone"
+  title: string
+  description: string
+  achievedAt?: string
+  threshold?: number
+}
+
+export interface SalesDashboardStats {
+  totalQuotes: number
+  activeQuotes: number
+  acceptedQuotes: number
+  totalRevenue: number
+  totalCommission: number
+  conversionRate: number
+}
+
+export interface GuidedTourStep {
+  id: string
+  target: string
+  title: string
+  description: string
+  placement: "top" | "bottom" | "left" | "right"
+}


### PR DESCRIPTION
## Summary
- **SALE-01**: Guided 4-step tooltip walkthrough for partner's first sale flow (auto-shows on first visit, skippable, localStorage-persisted)
- **SALE-02**: Clear visual quote states with color-coded status badges (draft/sent/accepted/expired), lifecycle timeline with dates, and expiry notices
- **SALE-03**: Commission visibility panel showing earnings (85% partner share), pending amounts, per-quote breakdown, and running totals
- **SALE-04**: First sale celebration with 60-piece confetti animation, trophy modal, FRED mentor quote, deal value + commission display, share CTA

Also includes: create quote modal with live commission preview, quote cards with line items, milestone tracker (4 achievements), stats overview (total/active/accepted/conversion), filter-by-status UI

## New Files
- `types/sales.ts` — Quote, Commission, Milestone, GuidedTourStep types
- `lib/sales/demo-data.ts` — Demo quotes, stats, milestones, commission calculator
- `components/sales/` — 7 components (quote-card, quote-status-badge, quote-timeline, commission-panel, create-quote-modal, first-sale-celebration, guided-tour)
- `app/dashboard/sales/page.tsx` — Sales dashboard page
- `app/dashboard/layout.tsx` — Added Sales nav item

## Verification
- `npm run build` passes clean
- Navigate to `/dashboard/sales` to see the full experience
- First visit triggers the guided tour walkthrough
- First sale celebration shows once (confetti + modal)
- Filter quotes by status using the pill buttons
- Click "New Quote" to open the create quote modal with live commission preview

Linear: AI-1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)