### PR TITLE
AI-8503: remove broken Sentry tunnelRoute so client events actually ship

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -87,7 +87,17 @@ const finalConfig = process.env.NEXT_PUBLIC_SENTRY_DSN
       widenClientFileUpload: true,
       hideSourceMaps: true,
       disableLogger: true,
-      tunnelRoute: "/monitoring-tunnel",
+      // tunnelRoute intentionally OMITTED. Prior setting ("/monitoring-tunnel")
+      // relied on the Sentry Next.js plugin to auto-emit a route handler, but
+      // with Next 16 + Serwist outer wrap the handler never materializes --
+      // https://www.joinsahara.com/monitoring-tunnel returns 404 to GET + POST
+      // (verified against prod a89daa2 and a preview deployment). Result:
+      // every client-side Sentry event was POSTed to a dead endpoint and
+      // dropped. Without tunnelRoute, events go directly to
+      // *.ingest.us.sentry.io. Ad-blockers can see + block that host for
+      // single-digit % of users; that's a meaningful improvement over
+      // losing 100% of client errors. Re-enable only after adding a real
+      // handler at the configured path and verifying 200-on-POST in prod.
     })
   : serwistConfig;
 


### PR DESCRIPTION
## Summary

Removes `tunnelRoute: "/monitoring-tunnel"` from `withSentryConfig` in `next.config.mjs`. With Next.js 16 + Serwist outer wrap, the Sentry Next.js plugin does **not** auto-generate the tunnel route handler -- GET and POST to `https://www.joinsahara.com/monitoring-tunnel` both return 404 (verified against prod `a89daa2` and a preview deployment).

Every client-side Sentry event has been POSTing to that dead endpoint and getting silently dropped since `tunnelRoute` was added. Server-side Sentry is unaffected.

## Why a dedicated PR

This fix was originally committed on `feat/firebase-to-supabase-migration` (PR #156), but that PR bundles a large Firebase->Supabase migration kit and is not close to merging. Sentry has been blind to 100% of client errors + replays in the meantime, so the one-line fix is worth extracting into its own small PR that can merge + deploy today.

Once `main` picks up this fix via this PR, the same commit on PR #156 will auto-reconcile on rebase.

## Changes

- `next.config.mjs` -- drop `tunnelRoute`, replace with an explanatory comment block so nobody re-adds it without first building the route handler

## Trade-off

Without the tunnel, events go directly to `*.ingest.us.sentry.io`. Ad-blockers can see + block that host for a single-digit % of users. Previous behaviour was losing 100% of client errors, so this is net positive.

Re-enable `tunnelRoute` only after adding a real handler at the configured path and verifying 200-on-POST in prod.

## Verification (post-merge)

1. Visit https://www.joinsahara.com in Chrome with DevTools Network tab open.
2. In the console, run `throw new Error('sentry-test-ai-8503')`.
3. Confirm a POST to `o4511012571643904.ingest.us.sentry.io` returns **200** (currently it would have gone to `/monitoring-tunnel` -> 404).
4. Check the Sentry dashboard -- the `sentry-test-ai-8503` event should appear within ~30s.

Linear: AI-8503

🤖 Generated with [Claude Code](https://claude.com/claude-code)