### PR TITLE
AI-8503: fix(sentry) remove broken tunnelRoute so client events ship

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -87,7 +87,18 @@ const finalConfig = process.env.NEXT_PUBLIC_SENTRY_DSN
       widenClientFileUpload: true,
       hideSourceMaps: true,
       disableLogger: true,
-      tunnelRoute: "/monitoring-tunnel",
+      // tunnelRoute intentionally OMITTED (AI-8503). The prior setting
+      // ("/monitoring-tunnel") relied on the Sentry Next.js plugin to
+      // auto-generate a route handler, but with Next 16 + Serwist outer
+      // wrap the handler never materializes -- /monitoring-tunnel returns
+      // 404 on both GET and POST (verified against prod a89daa2 and a
+      // preview deployment). Every client-side Sentry event was POSTed to
+      // the dead endpoint and silently dropped. Without tunnelRoute,
+      // events go directly to *.ingest.us.sentry.io. Ad-blockers can
+      // block that host for a single-digit % of users, but that is a
+      // significant improvement over losing 100% of client errors.
+      // Re-enable only after adding a real route handler at the configured
+      // path and verifying 200-on-POST in production.
     })
   : serwistConfig;
 


### PR DESCRIPTION
## Summary

- Remove broken `tunnelRoute: "/monitoring-tunnel"` from `withSentryConfig` in `next.config.mjs`
- With Next.js 16 + Serwist outer wrap, the Sentry plugin never auto-generates the tunnel route handler, so `/monitoring-tunnel` returns 404 on GET and POST
- Every client-side Sentry event was POSTed to the dead endpoint and silently dropped (server-side Sentry was unaffected)
- Without `tunnelRoute`, events go directly to `*.ingest.us.sentry.io` -- ad-blockers may block ~single-digit % of users, but that's a massive improvement over losing 100% of client errors

## Verification

- [x] `npm run build` passes cleanly
- [x] `npm test` passes (1067/1068 -- 1 pre-existing failure in `readiness.test.tsx` unrelated to this change)
- [x] Sentry client config (`sentry.client.config.ts`) uses DSN directly, no tunnel references
- [x] No other files reference `/monitoring-tunnel`

## Test plan

- [ ] After merge + deploy, trigger a client-side error on joinsahara.com and verify it appears in Sentry dashboard
- [ ] Check Sentry dashboard for new client-side events within 24h of deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)