### PR TITLE
AI-8499: Add in-app bug report widget for authenticated users

### DIFF
--- a/app/api/bug-report/route.ts
+++ b/app/api/bug-report/route.ts
@@ -1,0 +1,257 @@
+import { NextRequest, NextResponse } from "next/server"
+import { createClient, createServiceClient } from "@/lib/supabase/server"
+
+/**
+ * POST /api/bug-report
+ *
+ * AI-8499: Accept user-submitted bug reports from the in-app widget.
+ * Stores in Supabase `bug_reports` table and creates a Linear issue.
+ *
+ * Body: {
+ *   title: string,
+ *   description: string,
+ *   category: string,
+ *   pageUrl: string,
+ *   userAgent?: string,
+ * }
+ */
+
+const LINEAR_TEAM = "Ai Acrobatics"
+const VALID_CATEGORIES = ["ui", "functionality", "performance", "data", "other"]
+
+export async function POST(req: NextRequest) {
+  // 1. Auth
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
+  // 2. Parse body
+  let body: Record<string, unknown>
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 })
+  }
+
+  const { title, description, category, pageUrl, userAgent } = body as {
+    title?: string
+    description?: string
+    category?: string
+    pageUrl?: string
+    userAgent?: string
+  }
+
+  // 3. Validate
+  if (!title || typeof title !== "string" || title.trim().length === 0) {
+    return NextResponse.json({ error: "Title is required" }, { status: 400 })
+  }
+  if (
+    !description ||
+    typeof description !== "string" ||
+    description.trim().length === 0
+  ) {
+    return NextResponse.json(
+      { error: "Description is required" },
+      { status: 400 }
+    )
+  }
+  if (title.length > 200) {
+    return NextResponse.json(
+      { error: "Title must be 200 characters or less" },
+      { status: 400 }
+    )
+  }
+  if (description.length > 2000) {
+    return NextResponse.json(
+      { error: "Description must be 2000 characters or less" },
+      { status: 400 }
+    )
+  }
+
+  const safeCategory = VALID_CATEGORIES.includes(category ?? "")
+    ? category!
+    : "other"
+
+  // 4. Get user profile for context
+  const serviceClient = createServiceClient()
+  const { data: profile } = await serviceClient
+    .from("profiles")
+    .select("name, email, stage")
+    .eq("id", user.id)
+    .single()
+
+  // 5. Store in Supabase
+  const { data: bugReport, error: insertError } = await serviceClient
+    .from("bug_reports")
+    .insert({
+      user_id: user.id,
+      user_email: user.email || profile?.email || "",
+      user_name: profile?.name || "",
+      title: title.trim(),
+      description: description.trim(),
+      category: safeCategory,
+      page_url: (pageUrl as string) || "",
+      user_agent: ((userAgent as string) || "").slice(0, 500),
+      status: "open",
+    })
+    .select("id")
+    .single()
+
+  if (insertError) {
+    console.error("[bug-report] Insert error:", insertError)
+    return NextResponse.json(
+      { error: "Failed to save bug report" },
+      { status: 500 }
+    )
+  }
+
+  // 6. Create Linear issue (best-effort, don't block on failure)
+  let linearIdentifier: string | null = null
+  let linearUrl: string | null = null
+
+  try {
+    const linearResult = await createLinearBugIssue({
+      title: title.trim(),
+      description: description.trim(),
+      category: safeCategory,
+      pageUrl: (pageUrl as string) || "",
+      userName: profile?.name || user.email || "Unknown",
+      userEmail: user.email || "",
+      bugReportId: bugReport.id,
+    })
+
+    if (linearResult.success) {
+      linearIdentifier = linearResult.identifier ?? null
+      linearUrl = linearResult.url ?? null
+
+      // Update bug report with Linear issue link
+      await serviceClient
+        .from("bug_reports")
+        .update({
+          linear_issue_id: linearIdentifier,
+          linear_issue_url: linearUrl,
+        })
+        .eq("id", bugReport.id)
+    }
+  } catch (err) {
+    console.error("[bug-report] Linear issue creation failed:", err)
+  }
+
+  return NextResponse.json(
+    {
+      success: true,
+      id: bugReport.id,
+      linearIssue: linearIdentifier,
+    },
+    { status: 201 }
+  )
+}
+
+// ── Linear Issue Creation ──────────────────────────────────────────
+
+interface LinearBugInput {
+  title: string
+  description: string
+  category: string
+  pageUrl: string
+  userName: string
+  userEmail: string
+  bugReportId: string
+}
+
+interface LinearResult {
+  success: boolean
+  identifier?: string
+  url?: string
+  error?: string
+}
+
+async function createLinearBugIssue(input: LinearBugInput): Promise<LinearResult> {
+  const apiKey = process.env.LINEAR_API_KEY
+  if (!apiKey) {
+    return { success: false, error: "LINEAR_API_KEY not configured" }
+  }
+
+  // Get team ID
+  const teamQuery = await fetch("https://api.linear.app/graphql", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({
+      query: `query { teams(filter: { name: { eq: "${LINEAR_TEAM}" } }) { nodes { id } } }`,
+    }),
+  })
+
+  const teamData = await teamQuery.json()
+  const teamId = teamData.data?.teams?.nodes?.[0]?.id
+  if (!teamId) {
+    return { success: false, error: `Team "${LINEAR_TEAM}" not found` }
+  }
+
+  const categoryLabel: Record<string, string> = {
+    ui: "UI / Visual",
+    functionality: "Broken Feature",
+    performance: "Performance",
+    data: "Wrong Data",
+    other: "Other",
+  }
+
+  const issueDescription = `## User Bug Report
+
+**Reporter:** ${input.userName} (${input.userEmail})
+**Category:** ${categoryLabel[input.category] || input.category}
+**Page:** ${input.pageUrl || "N/A"}
+**Report ID:** \`${input.bugReportId}\`
+
+### Description
+${input.description}
+
+---
+*Submitted via in-app bug report widget*`
+
+  // Create issue with priority 3 (Normal) and label
+  const createRes = await fetch("https://api.linear.app/graphql", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: apiKey,
+    },
+    body: JSON.stringify({
+      query: `mutation CreateIssue($input: IssueCreateInput!) {
+        issueCreate(input: $input) {
+          success
+          issue { id identifier url }
+        }
+      }`,
+      variables: {
+        input: {
+          teamId,
+          title: `[Bug] ${input.title}`,
+          description: issueDescription,
+          priority: 3,
+        },
+      },
+    }),
+  })
+
+  const createData = await createRes.json()
+  const issue = createData.data?.issueCreate?.issue
+
+  if (!issue?.identifier) {
+    const errorDetail = JSON.stringify(createData.errors || createData)
+    return { success: false, error: `Linear issue creation failed: ${errorDetail}` }
+  }
+
+  return {
+    success: true,
+    identifier: issue.identifier,
+    url: issue.url,
+  }
+}

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -48,6 +48,7 @@ import { PageTransition } from "@/components/animations/PageTransition";
 import { VoiceChatOverlay } from "@/components/chat/voice-chat-overlay";
 import { EventFeedbackWidget } from "@/components/event-feedback-widget";
 import { EventMicroSurvey } from "@/components/event-micro-survey";
+import { BugReportWidget } from "@/components/bug-report-widget";
 
 // ============================================================================
 // Navigation Configuration
@@ -516,6 +517,9 @@ export default function DashboardLayout({
       />
 
       {/* AI-1804: Event feedback collection for first 200 attendees */}
+      {/* AI-8499: Bug report widget -- all authenticated users */}
+      <BugReportWidget />
+
       <EventFeedbackWidget />
       <EventMicroSurvey />
     </div>

--- a/components/bug-report-widget.tsx
+++ b/components/bug-report-widget.tsx
@@ -1,0 +1,213 @@
+"use client"
+
+/**
+ * Bug Report Widget
+ *
+ * AI-8499: Floating "Report a Bug" button visible on all authenticated dashboard pages.
+ * Opens a modal with: title, description, category, auto-attached page URL + user ID.
+ * Submits to POST /api/bug-report which stores in Supabase and creates a Linear issue.
+ */
+
+import { useState } from "react"
+import { usePathname } from "next/navigation"
+import { Bug } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { toast } from "sonner"
+import { cn } from "@/lib/utils"
+
+const BUG_CATEGORIES = [
+  { value: "ui", label: "UI / Visual" },
+  { value: "functionality", label: "Broken Feature" },
+  { value: "performance", label: "Slow / Laggy" },
+  { value: "data", label: "Wrong Data" },
+  { value: "other", label: "Other" },
+] as const
+
+type BugCategory = (typeof BUG_CATEGORIES)[number]["value"]
+
+export function BugReportWidget() {
+  const [open, setOpen] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const pathname = usePathname()
+
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("")
+  const [category, setCategory] = useState<BugCategory | "">("")
+
+  function resetForm() {
+    setTitle("")
+    setDescription("")
+    setCategory("")
+    setSubmitted(false)
+  }
+
+  function handleOpen() {
+    if (submitted) resetForm()
+    setOpen(true)
+  }
+
+  async function handleSubmit() {
+    if (!title.trim()) {
+      toast.error("Please provide a short title for the bug")
+      return
+    }
+    if (!description.trim()) {
+      toast.error("Please describe what happened")
+      return
+    }
+
+    setSubmitting(true)
+    try {
+      const res = await fetch("/api/bug-report", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim(),
+          category: category || "other",
+          pageUrl: pathname,
+          userAgent: navigator.userAgent,
+        }),
+      })
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        throw new Error(data.error || "Failed to submit bug report")
+      }
+
+      toast.success("Bug reported! We'll look into it.")
+      setSubmitted(true)
+      setOpen(false)
+      resetForm()
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to submit bug report"
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      {/* Floating bug report button -- bottom-left, above mobile nav */}
+      <button
+        onClick={handleOpen}
+        aria-label="Report a bug"
+        className={cn(
+          "fixed z-50 left-4 lg:left-6",
+          "bottom-[calc(5rem+env(safe-area-inset-bottom,0px))]",
+          "md:bottom-[calc(1.5rem+env(safe-area-inset-bottom,0px))]",
+          "flex items-center gap-2 rounded-full px-4 py-2.5",
+          "bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900",
+          "shadow-lg hover:shadow-xl transition-all duration-200",
+          "hover:scale-105 active:scale-95",
+          "text-sm font-medium"
+        )}
+      >
+        <Bug className="h-4 w-4" />
+        <span className="hidden sm:inline">Report Bug</span>
+      </button>
+
+      {/* Bug report modal */}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-w-md max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Report a Bug</DialogTitle>
+            <DialogDescription>
+              Found something broken? Let us know and we&apos;ll fix it.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            {/* Title */}
+            <div className="space-y-1.5">
+              <label
+                htmlFor="bug-title"
+                className="text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                What went wrong? <span className="text-red-500">*</span>
+              </label>
+              <Input
+                id="bug-title"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder='e.g. "Dashboard chart not loading"'
+                maxLength={200}
+              />
+            </div>
+
+            {/* Category */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Category
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {BUG_CATEGORIES.map((cat) => (
+                  <button
+                    key={cat.value}
+                    type="button"
+                    onClick={() => setCategory(cat.value)}
+                    className={cn(
+                      "rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
+                      category === cat.value
+                        ? "border-[#ff6a1a] bg-[#ff6a1a]/10 text-[#ff6a1a]"
+                        : "border-gray-200 text-gray-600 hover:border-gray-300 dark:border-gray-700 dark:text-gray-400"
+                    )}
+                  >
+                    {cat.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Description */}
+            <div className="space-y-1.5">
+              <label
+                htmlFor="bug-description"
+                className="text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                Details <span className="text-red-500">*</span>
+              </label>
+              <Textarea
+                id="bug-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What were you doing? What happened vs. what you expected?"
+                rows={4}
+                maxLength={2000}
+              />
+              <p className="text-xs text-gray-400">
+                {description.length}/2000
+              </p>
+            </div>
+
+            {/* Auto-attached context note */}
+            <p className="text-xs text-gray-400">
+              Page URL and your account are automatically attached.
+            </p>
+
+            {/* Submit */}
+            <Button
+              onClick={handleSubmit}
+              disabled={submitting}
+              className="w-full bg-[#ff6a1a] hover:bg-[#ea580c]"
+            >
+              {submitting ? "Submitting..." : "Submit Bug Report"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/supabase/migrations/20260422000001_create_bug_reports.sql
+++ b/supabase/migrations/20260422000001_create_bug_reports.sql
@@ -1,0 +1,32 @@
+-- AI-8499: Bug report widget - user-submitted bug reports
+create table if not exists public.bug_reports (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  user_email text not null default '',
+  user_name text not null default '',
+  title text not null,
+  description text not null,
+  category text not null default 'other',
+  page_url text not null default '',
+  user_agent text not null default '',
+  status text not null default 'open',
+  linear_issue_id text,
+  linear_issue_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- RLS: users can insert their own reports, admins can read all
+alter table public.bug_reports enable row level security;
+
+create policy "Users can insert their own bug reports"
+  on public.bug_reports for insert
+  with check (auth.uid() = user_id);
+
+create policy "Users can view their own bug reports"
+  on public.bug_reports for select
+  using (auth.uid() = user_id);
+
+-- Index for admin queries
+create index if not exists idx_bug_reports_status on public.bug_reports(status);
+create index if not exists idx_bug_reports_created on public.bug_reports(created_at desc);


### PR DESCRIPTION
## Summary
- Adds a floating "Report Bug" button (bottom-left) on all authenticated dashboard pages
- Opens a modal with: title, description, 5 bug categories, auto-attached page URL
- Submissions stored in new `bug_reports` Supabase table with RLS policies
- Auto-creates Linear issues with `[Bug]` prefix and Normal priority
- Follows existing patterns: shadcn Dialog, sonner toasts, orange brand colors

## Files Changed
- `components/bug-report-widget.tsx` — New floating FAB + modal component
- `app/api/bug-report/route.ts` — New POST endpoint (auth, validation, DB insert, Linear GraphQL)
- `app/dashboard/layout.tsx` — Wire widget into dashboard layout
- `supabase/migrations/20260422000001_create_bug_reports.sql` — New table + RLS + indexes

## Test Plan
- [ ] Verify floating button appears on dashboard pages (bottom-left, doesn't overlap chat widget)
- [ ] Open modal, fill form, submit — check toast confirmation
- [ ] Verify bug_reports row created in Supabase
- [ ] Verify Linear issue created with correct title/description
- [ ] Test validation: empty title/description shows error toast
- [ ] Test mobile: button shows bug icon only (no text), modal scrollable
- [ ] Run migration on Supabase

Closes AI-8499

Linear: https://linear.app/ai-acrobatics/issue/AI-8499/sahara-bug-reporting-ai-trained-support-widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)