### PR TITLE
AI-8503: fix Sentry client-side events dropped (remove broken tunnelRoute)

### DIFF
--- a/components/chat/voice-chat-overlay.tsx
+++ b/components/chat/voice-chat-overlay.tsx
@@ -163,7 +163,7 @@ export function VoiceChatOverlay({
           {!isSupported && (
             <div className="bg-red-500/20 border border-red-500/40 rounded-xl p-4 text-center">
               <p className="text-white text-sm">
-                Voice input isn't supported on this browser. Please use Chrome, Safari, or Edge.
+                Voice input isn&apos;t supported on this browser. Please use Chrome, Safari, or Edge.
               </p>
             </div>
           )}

--- a/lib/feedback/whatsapp-reply.ts
+++ b/lib/feedback/whatsapp-reply.ts
@@ -6,8 +6,8 @@ export async function sendWhatsAppMessage(
   groupName: string,
   message: string
 ): Promise<{ success: boolean; error?: string }> {
-  const { exec } = require("child_process");
-  const { promisify } = require("util");
+  const { exec } = await import("child_process");
+  const { promisify } = await import("util");
   const execAsync = promisify(exec);
 
   // Escape special characters for AppleScript

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,7 +19,7 @@ function generateCsp(nonce: string): string {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",
-    "connect-src 'self' https://*.supabase.co https://api.stripe.com wss://*.supabase.co https://*.livekit.cloud wss://*.livekit.cloud https://*.anthropic.com https://*.openai.com https://*.ingest.sentry.io https://*.msgsndr.com https://*.posthog.com",
+    "connect-src 'self' https://*.supabase.co https://api.stripe.com wss://*.supabase.co https://*.livekit.cloud wss://*.livekit.cloud https://*.anthropic.com https://*.openai.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.msgsndr.com https://*.posthog.com",
     "worker-src 'self'",
     "media-src 'self' blob:",
     "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -87,7 +87,17 @@ const finalConfig = process.env.NEXT_PUBLIC_SENTRY_DSN
       widenClientFileUpload: true,
       hideSourceMaps: true,
       disableLogger: true,
-      tunnelRoute: "/monitoring-tunnel",
+      // tunnelRoute intentionally OMITTED. Prior setting ("/monitoring-tunnel")
+      // relied on the Sentry Next.js plugin to auto-emit a route handler, but
+      // with Next 16 + Serwist outer wrap the handler never materializes --
+      // https://www.joinsahara.com/monitoring-tunnel returns 404 to GET + POST
+      // (verified against prod a89daa2 and a preview deployment). Result:
+      // every client-side Sentry event was POSTed to a dead endpoint and
+      // dropped. Without tunnelRoute, events go directly to
+      // *.ingest.us.sentry.io. Ad-blockers can see + block that host for
+      // single-digit % of users; that's a meaningful improvement over
+      // losing 100% of client errors. Re-enable only after adding a real
+      // handler at the configured path and verifying 200-on-POST in prod.
     })
   : serwistConfig;
 


### PR DESCRIPTION
## Summary

- **Removed broken `tunnelRoute: "/monitoring-tunnel"`** from `withSentryConfig` in `next.config.mjs`
- The Sentry Next.js plugin was supposed to auto-generate a route handler at `/monitoring-tunnel`, but with Next.js 16 + Serwist outer wrap the handler never materializes -- both GET and POST to `https://www.joinsahara.com/monitoring-tunnel` return 404
- **Net effect**: 100% of client-side Sentry events (errors + replays) were being POSTed to a dead endpoint and silently dropped. Server-side Sentry was unaffected
- Without `tunnelRoute`, client events now POST directly to `*.ingest.us.sentry.io` via the standard SDK path
- Trade-off: ad-blockers can block the ingest host (estimated single-digit % of users), but that's far better than losing 100% of client errors
- Also resolves 3 ESLint errors that were blocking CI

## Verification

- [x] `tunnelRoute` removed from `next.config.mjs`
- [x] `sentry.client.config.ts` correctly initializes with DSN, replay integration, and error filtering
- [x] `sentry.server.config.ts` and `sentry.edge.config.ts` configs unchanged and correct
- [x] Test suite passes (pre-existing coaching/documents test failures are unrelated)
- [x] No regressions introduced

## Test plan

- [ ] After merge + deploy, check Sentry dashboard for incoming client-side events within 5 minutes
- [ ] Trigger a client-side error (e.g., console error boundary) and confirm it appears in Sentry
- [ ] Verify Session Replay events are recording on error (replaysOnErrorSampleRate: 1.0)

Linear: AI-8503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>