### PR TITLE
AI-8503: fix CSP blocking Sentry client-side events

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -19,7 +19,7 @@ function generateCsp(nonce: string): string {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",
-    "connect-src 'self' https://*.supabase.co https://api.stripe.com wss://*.supabase.co https://*.livekit.cloud wss://*.livekit.cloud https://*.anthropic.com https://*.openai.com https://*.ingest.sentry.io https://*.msgsndr.com https://*.posthog.com",
+    "connect-src 'self' https://*.supabase.co https://api.stripe.com wss://*.supabase.co https://*.livekit.cloud wss://*.livekit.cloud https://*.anthropic.com https://*.openai.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.msgsndr.com https://*.posthog.com",
     "worker-src 'self'",
     "media-src 'self' blob:",
     "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",


### PR DESCRIPTION
## Summary

- Adds `https://*.ingest.us.sentry.io` to the CSP `connect-src` directive in `middleware.ts`

## Context

PR #156 correctly removed the dead `tunnelRoute: "/monitoring-tunnel"` from `next.config.mjs`, which was silently dropping 100% of client-side Sentry events. However, browser-based verification revealed that events are **still being blocked** by Content Security Policy.

The CSP `connect-src` directive had `https://*.ingest.sentry.io`, but the actual Sentry ingest URL is `https://o4511012571643904.ingest.us.sentry.io`. CSP wildcards match only one subdomain level, so the `.us.` region segment creates a mismatch. Every client-side Sentry POST gets blocked with a CSP violation.

## Fix

Add `https://*.ingest.us.sentry.io` alongside the existing generic pattern. This covers the US region while keeping the generic pattern for future region changes.

## Testing

- [ ] Deploy preview, open DevTools Console, run `throw new Error('sentry-test')`, verify POST to `ingest.us.sentry.io` succeeds (no CSP violation)
- [ ] Check Sentry dashboard for the test event
- [ ] No regressions in other CSP-protected functionality

Closes AI-8503

🤖 Generated with [Claude Code](https://claude.com/claude-code)