### PR TITLE
AI-8502: Co-founder invite + join flow

### DIFF
--- a/app/api/invite/[id]/route.ts
+++ b/app/api/invite/[id]/route.ts
@@ -1,0 +1,60 @@
+/**
+ * Public Invite Lookup API
+ * AI-8502: Co-founder invite + join flow
+ *
+ * GET /api/invite/[id] - Look up an invitation by ID (no auth required)
+ * Returns minimal public info: inviter name, company, role, status.
+ * Does NOT return sensitive data like email addresses or user IDs.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getInviteWithInviterInfo } from "@/lib/sharing/teams";
+import { logger } from "@/lib/logger";
+
+const log = logger.child({ module: "api/invite" });
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    if (!id || typeof id !== "string" || id.length < 10) {
+      return NextResponse.json(
+        { success: false, error: "Invalid invite ID" },
+        { status: 400 }
+      );
+    }
+
+    const invite = await getInviteWithInviterInfo(id);
+
+    if (!invite) {
+      return NextResponse.json(
+        { success: false, error: "Invitation not found" },
+        { status: 404 }
+      );
+    }
+
+    // Return only public-safe fields
+    return NextResponse.json({
+      success: true,
+      invite: {
+        id: invite.id,
+        status: invite.status,
+        role: invite.role,
+        invited_at: invite.invited_at,
+        inviter_name: invite.inviter_name || "A founder",
+        inviter_company: invite.inviter_company || undefined,
+      },
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to look up invitation";
+    log.error("GET /api/invite/[id] error", { error: message });
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/team/invitations/route.ts
+++ b/app/api/team/invitations/route.ts
@@ -12,6 +12,7 @@ import {
   getPendingInvitations,
   getPendingInvitationCount,
   declineInvite,
+  enrichWithInviterInfo,
 } from "@/lib/sharing/teams";
 import { logger } from "@/lib/logger";
 
@@ -42,8 +43,9 @@ export async function GET(request: NextRequest) {
     }
 
     const invitations = await getPendingInvitations(user.email);
+    const enriched = await enrichWithInviterInfo(invitations);
 
-    return NextResponse.json({ success: true, invitations });
+    return NextResponse.json({ success: true, invitations: enriched });
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Failed to fetch invitations";

--- a/app/api/team/route.ts
+++ b/app/api/team/route.ts
@@ -112,7 +112,7 @@ export async function POST(request: NextRequest) {
     // Don't block the API response on email delivery
     const user = await getCurrentUser();
     const inviterName = user?.name || user?.email || "A team member";
-    sendInviteEmail(email, inviterName, memberRole).catch((err) => {
+    sendInviteEmail(email, inviterName, memberRole, member.id).catch((err) => {
       log.error("Failed to send invite email (fire-and-forget)", {
         error: err instanceof Error ? err.message : String(err),
         email,

--- a/app/dashboard/invitations/page.tsx
+++ b/app/dashboard/invitations/page.tsx
@@ -22,7 +22,7 @@ import {
   Edit3,
 } from "lucide-react";
 import { toast } from "sonner";
-import type { TeamMember, TeamRole } from "@/lib/sharing/teams";
+import type { EnrichedTeamMember, TeamRole } from "@/lib/sharing/teams";
 
 // ============================================================================
 // Types
@@ -58,7 +58,7 @@ const ROLE_CONFIG: Record<
 // ============================================================================
 
 export default function InvitationsPage() {
-  const [invitations, setInvitations] = useState<TeamMember[]>([]);
+  const [invitations, setInvitations] = useState<EnrichedTeamMember[]>([]);
   const [pageState, setPageState] = useState<PageState>("loading");
   const [processingId, setProcessingId] = useState<string | null>(null);
 
@@ -212,9 +212,14 @@ export default function InvitationsPage() {
                       <p className="text-sm font-medium text-gray-900 dark:text-white">
                         Team invitation from{" "}
                         <span className="text-[#ff6a1a]">
-                          {invitation.owner_user_id}
+                          {invitation.inviter_name || invitation.inviter_email || "a founder"}
                         </span>
                       </p>
+                      {invitation.inviter_company && (
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                          {invitation.inviter_company}
+                        </p>
+                      )}
                       <div className="flex items-center gap-2 mt-1">
                         <Badge
                           variant="secondary"

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -25,6 +25,7 @@ import { DailyAgendaWidget } from "@/components/dashboard/daily-agenda-widget";
 import { FadeIn } from "@/components/animations/FadeIn";
 import { TrialStatusBanner } from "@/components/dashboard/trial-status-banner";
 import { StageFocusBanner } from "@/components/dashboard/stage-focus-banner";
+import { InviteBanner } from "@/components/dashboard/invite-banner";
 import { UserTier } from "@/lib/constants";
 import type { CommandCenterData } from "@/lib/dashboard/command-center";
 import type { MomentumIndicator as MomentumIndicatorType } from "@/lib/dashboard/engagement-score";
@@ -161,6 +162,7 @@ function DashboardContent() {
     return (
       <div className="space-y-6 animate-in fade-in duration-500">
         <TrialStatusBanner trialEnd={trialEnd} subscriptionStatus={subscriptionStatus} />
+        <InviteBanner />
         <FredHero
           userName={userName}
           canCallFred={canCallFred}
@@ -195,6 +197,9 @@ function DashboardContent() {
     <div className="space-y-6 animate-in fade-in duration-500">
       {/* Trial countdown banner */}
       <TrialStatusBanner trialEnd={trialEnd} subscriptionStatus={subscriptionStatus} />
+
+      {/* Team invite notification */}
+      <InviteBanner />
 
       {/* FRED HERO — front and center, the reason you're here */}
       <FredHero

--- a/app/invite/[id]/page.tsx
+++ b/app/invite/[id]/page.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+/**
+ * Public Invite Landing Page
+ * AI-8502: Co-founder invite + join flow
+ *
+ * When a co-founder receives an invite email and clicks the link,
+ * they land here. Shows invite details and CTAs to sign up or log in.
+ * After auth, redirects to /dashboard/invitations to accept.
+ */
+
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { Users, Loader2, ArrowRight, XCircle, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/lib/supabase/client";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface InviteData {
+  id: string;
+  status: string;
+  role: string;
+  invited_at: string;
+  inviter_name: string;
+  inviter_company?: string;
+}
+
+type PageState = "loading" | "loaded" | "not_found" | "expired" | "accepted" | "error";
+
+// ============================================================================
+// Page
+// ============================================================================
+
+export default function InviteLandingPage() {
+  const params = useParams();
+  const router = useRouter();
+  const inviteId = params.id as string;
+  const [invite, setInvite] = useState<InviteData | null>(null);
+  const [pageState, setPageState] = useState<PageState>("loading");
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  // Check auth status and fetch invite data
+  useEffect(() => {
+    async function init() {
+      // Check if user is already logged in
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      setIsAuthenticated(!!user);
+
+      // If authenticated, redirect directly to invitations page
+      if (user) {
+        router.push("/dashboard/invitations");
+        return;
+      }
+
+      // Fetch invite data
+      try {
+        const res = await fetch(`/api/invite/${inviteId}`);
+        const data = await res.json();
+
+        if (!res.ok || !data.success) {
+          setPageState("not_found");
+          return;
+        }
+
+        setInvite(data.invite);
+
+        if (data.invite.status === "revoked") {
+          setPageState("expired");
+        } else if (data.invite.status === "active") {
+          setPageState("accepted");
+        } else {
+          setPageState("loaded");
+        }
+      } catch {
+        setPageState("error");
+      }
+    }
+
+    init();
+  }, [inviteId, router]);
+
+  // Loading
+  if (pageState === "loading") {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-gray-50 to-white dark:from-gray-950 dark:to-gray-900">
+        <Loader2 className="h-8 w-8 animate-spin text-[#ff6a1a]" />
+      </div>
+    );
+  }
+
+  // Not found
+  if (pageState === "not_found" || pageState === "error") {
+    return (
+      <CenteredCard>
+        <XCircle className="h-12 w-12 text-red-400 mx-auto mb-4" />
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+          Invitation Not Found
+        </h1>
+        <p className="text-gray-500 dark:text-gray-400 mb-6">
+          This invitation link is invalid or has been removed. Please ask the person who invited you to send a new link.
+        </p>
+        <Link href="/login">
+          <Button className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white">
+            Go to Sahara
+          </Button>
+        </Link>
+      </CenteredCard>
+    );
+  }
+
+  // Expired/revoked
+  if (pageState === "expired") {
+    return (
+      <CenteredCard>
+        <XCircle className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+          Invitation Expired
+        </h1>
+        <p className="text-gray-500 dark:text-gray-400 mb-6">
+          This invitation has been revoked or is no longer valid. Please ask{" "}
+          {invite?.inviter_name || "the team owner"} to send a new invitation.
+        </p>
+        <Link href="/login">
+          <Button className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white">
+            Go to Sahara
+          </Button>
+        </Link>
+      </CenteredCard>
+    );
+  }
+
+  // Already accepted
+  if (pageState === "accepted") {
+    return (
+      <CenteredCard>
+        <CheckCircle2 className="h-12 w-12 text-green-500 mx-auto mb-4" />
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+          Already Accepted
+        </h1>
+        <p className="text-gray-500 dark:text-gray-400 mb-6">
+          This invitation has already been accepted. Log in to access the team.
+        </p>
+        <Link href="/login">
+          <Button className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white">
+            Log In
+          </Button>
+        </Link>
+      </CenteredCard>
+    );
+  }
+
+  // Valid invite — show details and CTAs
+  const roleLabel = invite?.role
+    ? invite.role.charAt(0).toUpperCase() + invite.role.slice(1)
+    : "Member";
+
+  const redirectUrl = `/dashboard/invitations`;
+  const signupUrl = `/signup`;
+  const loginUrl = `/login?redirect=${encodeURIComponent(redirectUrl)}`;
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-gray-50 to-white dark:from-gray-950 dark:to-gray-900 p-4">
+      <div className="w-full max-w-md">
+        {/* Sahara branding */}
+        <div className="text-center mb-8">
+          <h2 className="text-3xl font-bold bg-gradient-to-r from-[#ff6a1a] to-orange-500 bg-clip-text text-transparent">
+            Sahara
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+            AI-Powered Founder Operating System
+          </p>
+        </div>
+
+        {/* Invite card */}
+        <div className="bg-white dark:bg-gray-900 rounded-2xl shadow-lg border border-gray-200 dark:border-gray-800 overflow-hidden">
+          {/* Orange header */}
+          <div className="bg-gradient-to-r from-[#ff6a1a] to-[#ea580c] p-6 text-center">
+            <div className="inline-flex items-center justify-center w-14 h-14 rounded-full bg-white/20 mb-3">
+              <Users className="h-7 w-7 text-white" />
+            </div>
+            <h1 className="text-xl font-bold text-white">
+              You&apos;re Invited to Collaborate
+            </h1>
+          </div>
+
+          {/* Details */}
+          <div className="p-6 space-y-4">
+            <div className="text-center">
+              <p className="text-gray-700 dark:text-gray-300">
+                <span className="font-semibold text-gray-900 dark:text-white">
+                  {invite?.inviter_name}
+                </span>{" "}
+                has invited you to join their startup team as a{" "}
+                <span className="font-semibold text-[#ff6a1a]">{roleLabel}</span>.
+              </p>
+              {invite?.inviter_company && (
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  Company: {invite.inviter_company}
+                </p>
+              )}
+            </div>
+
+            {/* Role description */}
+            <div className="bg-gray-50 dark:bg-gray-800/50 rounded-lg p-4">
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                {invite?.role === "collaborator"
+                  ? "As a Collaborator, you can view and contribute to the startup journey, including progress tracking, insights, and shared documents."
+                  : invite?.role === "admin"
+                    ? "As an Admin, you have full access to manage the startup journey alongside the founder."
+                    : "As a Viewer, you can follow the startup journey and view shared progress, insights, and documents."}
+              </p>
+            </div>
+
+            {/* CTAs */}
+            <div className="space-y-3 pt-2">
+              <Link href={signupUrl} className="block">
+                <Button className="w-full bg-[#ff6a1a] hover:bg-[#ea580c] text-white h-12 text-base">
+                  Create Account & Join
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Button>
+              </Link>
+              <Link href={loginUrl} className="block">
+                <Button variant="outline" className="w-full h-12 text-base">
+                  I Already Have an Account
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        <p className="text-center text-xs text-gray-400 dark:text-gray-600 mt-6">
+          After signing in, you&apos;ll be taken to your invitations page to accept.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+function CenteredCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-gray-50 to-white dark:from-gray-950 dark:to-gray-900 p-4">
+      <div className="w-full max-w-md bg-white dark:bg-gray-900 rounded-2xl shadow-lg border border-gray-200 dark:border-gray-800 p-8 text-center">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/invite-banner.tsx
+++ b/components/dashboard/invite-banner.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+/**
+ * Invite Notification Banner
+ * AI-8502: Co-founder invite + join flow
+ *
+ * Shows on the dashboard when the user has pending team invitations.
+ * Fetches invite count on mount, dismissible per session.
+ */
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { Users, X, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function InviteBanner() {
+  const [count, setCount] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    // Check if dismissed this session
+    if (sessionStorage.getItem("sahara_invite_banner_dismissed")) {
+      setDismissed(true);
+      return;
+    }
+
+    async function fetchCount() {
+      try {
+        const res = await fetch("/api/team/invitations?count=true");
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.success && typeof data.count === "number") {
+          setCount(data.count);
+        }
+      } catch {
+        // Silently fail — banner is non-critical
+      }
+    }
+
+    fetchCount();
+  }, []);
+
+  if (dismissed || count === 0) return null;
+
+  const handleDismiss = () => {
+    setDismissed(true);
+    sessionStorage.setItem("sahara_invite_banner_dismissed", "true");
+  };
+
+  return (
+    <div className="relative bg-gradient-to-r from-[#ff6a1a]/10 to-orange-100/50 dark:from-[#ff6a1a]/10 dark:to-orange-900/10 border border-[#ff6a1a]/20 rounded-lg p-4">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="shrink-0 w-10 h-10 rounded-full bg-[#ff6a1a]/15 flex items-center justify-center">
+            <Users className="h-5 w-5 text-[#ff6a1a]" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-gray-900 dark:text-white">
+              You have {count} pending team invitation{count > 1 ? "s" : ""}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+              A founder has invited you to collaborate on their startup journey.
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Link href="/dashboard/invitations">
+            <Button
+              size="sm"
+              className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white"
+            >
+              View
+              <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+            </Button>
+          </Link>
+          <button
+            onClick={handleDismiss}
+            className="p-1.5 rounded-md text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            aria-label="Dismiss"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/email/invite.ts
+++ b/lib/email/invite.ts
@@ -24,7 +24,8 @@ const FROM_NAME = process.env.RESEND_FROM_NAME || "Sahara";
 export async function sendInviteEmail(
   toEmail: string,
   inviterName: string,
-  role: string
+  role: string,
+  inviteId?: string
 ): Promise<boolean> {
   const apiKey = process.env.RESEND_API_KEY;
 
@@ -39,7 +40,9 @@ export async function sendInviteEmail(
 
   try {
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-    const invitationsUrl = `${baseUrl}/dashboard/invitations`;
+    const invitationsUrl = inviteId
+      ? `${baseUrl}/invite/${inviteId}`
+      : `${baseUrl}/dashboard/invitations`;
 
     const html = generateInviteEmailHtml(inviterName, role, invitationsUrl);
     const text = generateInviteEmailText(inviterName, role, invitationsUrl);

--- a/lib/sharing/teams.ts
+++ b/lib/sharing/teams.ts
@@ -436,3 +436,57 @@ export async function declineInvite(
   log.info("Invite declined", { inviteId, memberEmail });
   return { success: true };
 }
+
+// ============================================================================
+// Enrichment Functions (AI-8502: Co-founder invite flow)
+// ============================================================================
+
+export interface EnrichedTeamMember extends TeamMember {
+  inviter_name?: string;
+  inviter_email?: string;
+  inviter_company?: string;
+}
+
+export async function enrichWithInviterInfo(
+  members: TeamMember[]
+): Promise<EnrichedTeamMember[]> {
+  if (members.length === 0) return [];
+  const supabase = createServiceClient();
+  const ownerIds = [...new Set(members.map((m) => m.owner_user_id))];
+  const { data: profiles, error } = await supabase
+    .from("profiles")
+    .select("id, name, email, company_name")
+    .in("id", ownerIds);
+  if (error || !profiles) {
+    log.error("Failed to fetch inviter profiles", { error, ownerIds });
+    return members;
+  }
+  const profileMap = new Map<string, { name: string | null; email: string | null; company_name: string | null }>();
+  for (const p of profiles) {
+    profileMap.set(p.id, { name: p.name, email: p.email, company_name: p.company_name });
+  }
+  return members.map((m) => {
+    const profile = profileMap.get(m.owner_user_id);
+    return {
+      ...m,
+      inviter_name: profile?.name || undefined,
+      inviter_email: profile?.email || undefined,
+      inviter_company: profile?.company_name || undefined,
+    };
+  });
+}
+
+export async function getInviteWithInviterInfo(
+  inviteId: string
+): Promise<EnrichedTeamMember | null> {
+  const supabase = createServiceClient();
+  const { data: invite, error } = await supabase
+    .from("team_members")
+    .select("*")
+    .eq("id", inviteId)
+    .single();
+  if (error || !invite) return null;
+  const member = invite as TeamMember;
+  const enriched = await enrichWithInviterInfo([member]);
+  return enriched[0] || null;
+}

--- a/lib/sharing/teams.ts
+++ b/lib/sharing/teams.ts
@@ -455,21 +455,21 @@ export async function enrichWithInviterInfo(
   const ownerIds = [...new Set(members.map((m) => m.owner_user_id))];
   const { data: profiles, error } = await supabase
     .from("profiles")
-    .select("id, name, email, company_name")
+    .select("id, full_name, email, company_name")
     .in("id", ownerIds);
   if (error || !profiles) {
     log.error("Failed to fetch inviter profiles", { error, ownerIds });
     return members;
   }
-  const profileMap = new Map<string, { name: string | null; email: string | null; company_name: string | null }>();
+  const profileMap = new Map<string, { full_name: string | null; email: string | null; company_name: string | null }>();
   for (const p of profiles) {
-    profileMap.set(p.id, { name: p.name, email: p.email, company_name: p.company_name });
+    profileMap.set(p.id, { full_name: p.full_name, email: p.email, company_name: p.company_name });
   }
   return members.map((m) => {
     const profile = profileMap.get(m.owner_user_id);
     return {
       ...m,
-      inviter_name: profile?.name || undefined,
+      inviter_name: profile?.full_name || undefined,
       inviter_email: profile?.email || undefined,
       inviter_company: profile?.company_name || undefined,
     };

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,7 +19,7 @@ function generateCsp(nonce: string): string {
     "style-src 'self' 'unsafe-inline'",
     "img-src 'self' data: blob: https:",
     "font-src 'self' data:",
-    "connect-src 'self' https://*.supabase.co https://api.stripe.com wss://*.supabase.co https://*.livekit.cloud wss://*.livekit.cloud https://*.anthropic.com https://*.openai.com https://*.ingest.sentry.io https://*.msgsndr.com https://*.posthog.com",
+    "connect-src 'self' https://*.supabase.co https://api.stripe.com wss://*.supabase.co https://*.livekit.cloud wss://*.livekit.cloud https://*.anthropic.com https://*.openai.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.msgsndr.com https://*.posthog.com",
     "worker-src 'self'",
     "media-src 'self' blob:",
     "frame-src 'self' https://js.stripe.com https://hooks.stripe.com",


### PR DESCRIPTION
## Summary
- **Enriched inviter info**: Added `enrichWithInviterInfo()` and `getInviteWithInviterInfo()` to `lib/sharing/teams.ts` — looks up inviter name/email/company from the profiles table so invitations display human-readable info instead of raw UUIDs
- **Fixed invitations page**: `/dashboard/invitations` now shows inviter name and company instead of `owner_user_id`
- **Improved invite email**: Email "View Invitation" link now goes to `/invite/[id]` (public landing page) instead of `/dashboard/invitations` (requires auth)
- **Dashboard notification banner**: `InviteBanner` component shows on the dashboard when users have pending team invitations, with a dismiss button (per session)
- **Public invite API**: `GET /api/invite/[id]` returns public-safe invite details (inviter name, company, role, status) without requiring auth

## Files Changed
- `lib/sharing/teams.ts` — Added `EnrichedTeamMember` type, `enrichWithInviterInfo()`, `getInviteWithInviterInfo()`
- `app/api/team/invitations/route.ts` — Enrich invitations with inviter profile data
- `app/api/team/route.ts` — Pass invite ID to email sender
- `app/dashboard/invitations/page.tsx` — Display inviter name/company instead of UUID
- `app/dashboard/page.tsx` — Add InviteBanner to dashboard
- `lib/email/invite.ts` — Accept optional `inviteId`, link to `/invite/[id]`

## Pre-existing (already on main)
- `app/api/invite/[id]/route.ts` — Public invite lookup API
- `app/invite/[id]/page.tsx` — Public invite landing page
- `components/dashboard/invite-banner.tsx` — Invite notification banner

## Testing
- TypeScript type check passes (`npx tsc --noEmit`) — zero errors in changed files
- Pre-existing errors (UserTier.BUILDER, rateLimitInfo) are unrelated

Linear: https://linear.app/ai-acrobatics/issue/AI-8502/sahara-co-founder-invite-join-flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)