### PR TITLE
AI-4104: wire Loom walkthrough video ID via env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -206,3 +206,12 @@ COMMUNITIES_ENABLED=true
 # Set to "true" to enable 14-day free trial on new Stripe subscriptions.
 # Default: false (Fred will flip when ready to launch trials).
 STRIPE_TRIALS_ENABLED=false
+
+# ======================
+# HOW TO USE SAHARA -- Loom walkthrough video (AI-4104)
+# ======================
+# Loom video ID for the "How To Use Sahara" dashboard modal.
+# When unset, the modal renders a "coming soon" placeholder.
+# To activate: record the walkthrough on Loom, grab the video ID from the share URL
+# (https://www.loom.com/share/<VIDEO_ID>), and set it here + in Vercel env vars.
+NEXT_PUBLIC_LOOM_WALKTHROUGH_ID=

--- a/components/dashboard/how-to-use-sahara-modal.tsx
+++ b/components/dashboard/how-to-use-sahara-modal.tsx
@@ -9,10 +9,11 @@ import {
 } from "@/components/ui/dialog"
 
 /**
- * Loom embed URL for the "How To Use Sahara" walkthrough video.
- * Replace the video ID below once the actual Loom recording is created.
+ * Loom video ID for the "How To Use Sahara" walkthrough.
+ * Set NEXT_PUBLIC_LOOM_WALKTHROUGH_ID in Vercel env vars once the recording exists.
+ * When unset, the modal renders a friendly "coming soon" placeholder.
  */
-const LOOM_VIDEO_ID = "placeholder"
+const LOOM_VIDEO_ID = process.env.NEXT_PUBLIC_LOOM_WALKTHROUGH_ID || "placeholder"
 const LOOM_EMBED_URL = `https://www.loom.com/embed/${LOOM_VIDEO_ID}`
 
 interface HowToUseSaharaModalProps {


### PR DESCRIPTION
## Summary

Makes the "How To Use Sahara" dashboard modal load its Loom video ID from `NEXT_PUBLIC_LOOM_WALKTHROUGH_ID` instead of a hardcoded placeholder. When Fred records the walkthrough, Julian just sets the env var in Vercel -- no code change required.

## Why this is not a full close-out

The Linear ticket asks for an actual Loom video recording, which requires a human (Fred or Julian). This PR closes the code-infrastructure portion only:

- [x] Modal reads Loom ID from env var
- [x] Placeholder still renders when env var is unset (no visible regression)
- [x] `.env.example` documents the variable
- [ ] Record the Loom video (human task -- releasing AI-4104 back to the queue for Fred/Julian)

Prior PR #151 attempted a larger change (quick-start guide + guided tour CTA) but has CI failures and merge conflicts. This PR is a minimal, focused wiring change that can land cleanly on main today.

## Changes
- `components/dashboard/how-to-use-sahara-modal.tsx` -- read `LOOM_VIDEO_ID` from `process.env.NEXT_PUBLIC_LOOM_WALKTHROUGH_ID`
- `.env.example` -- document the new variable with activation instructions

## Verification
- TypeScript clean (`npx tsc --noEmit` on the file)
- Without env var: modal shows existing "coming soon" placeholder -- unchanged behavior
- With env var set: modal renders the Loom iframe at `https://www.loom.com/embed/<id>`

Linear: AI-4104