### PR TITLE
[Pipeline] Sibling-sweep dedup for Linear issue creation (AI-4108)

### DIFF
--- a/app/api/bug-report/route.ts
+++ b/app/api/bug-report/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server"
 import { createClient, createServiceClient } from "@/lib/supabase/server"
+import { findExistingLinearIssue } from "@/lib/feedback/linear-auto-triage"
 
 /**
  * POST /api/bug-report
@@ -177,6 +178,19 @@ async function createLinearBugIssue(input: LinearBugInput): Promise<LinearResult
     return { success: false, error: "LINEAR_API_KEY not configured" }
   }
 
+  // AI-4108: dedup by exact title match before creating — if a user double-
+  // submits the same bug (network retry, duplicate click), reuse the existing
+  // issue rather than spawning a duplicate.
+  const issueTitle = `[Bug] ${input.title}`
+  const existing = await findExistingLinearIssue(apiKey, issueTitle)
+  if (existing) {
+    return {
+      success: true,
+      identifier: existing.identifier,
+      url: existing.url,
+    }
+  }
+
   // Get team ID
   const teamQuery = await fetch("https://api.linear.app/graphql", {
     method: "POST",
@@ -233,7 +247,7 @@ ${input.description}
       variables: {
         input: {
           teamId,
-          title: `[Bug] ${input.title}`,
+          title: issueTitle,
           description: issueDescription,
           priority: 3,
         },

--- a/lib/feedback/linear-auto-triage.ts
+++ b/lib/feedback/linear-auto-triage.ts
@@ -216,8 +216,11 @@ ${signalIdsFormatted}${truncation}`
 /**
  * Search Linear for an existing issue with an exact title match.
  * Returns the first match or null if none found.
+ *
+ * Exported so sibling callsites (WhatsApp monitor, bug-report route) can
+ * reuse the same dedup check before creating new issues (AI-4108).
  */
-async function findExistingLinearIssue(
+export async function findExistingLinearIssue(
   apiKey: string,
   title: string
 ): Promise<{ identifier: string; title: string; url: string } | null> {

--- a/trigger/sahara-whatsapp-monitor.ts
+++ b/trigger/sahara-whatsapp-monitor.ts
@@ -12,6 +12,7 @@
  * to track last check timestamp and avoid duplicate processing.
  */
 import { schedules, logger } from "@trigger.dev/sdk/v3";
+import { findExistingLinearIssue } from "@/lib/feedback/linear-auto-triage";
 
 // ── Types ───────────────────────────────────────────────────────
 interface WhatsAppMessage {
@@ -410,6 +411,16 @@ async function createLinearIssue(issue: IdentifiedIssue): Promise<string> {
   const apiKey = process.env.LINEAR_API_KEY;
   if (!apiKey) {
     throw new Error("LINEAR_API_KEY not configured");
+  }
+
+  // AI-4108: dedup by exact title match before creating — same theme detected
+  // across scheduled runs should not spawn duplicate Linear issues.
+  const existing = await findExistingLinearIssue(apiKey, issue.title);
+  if (existing) {
+    logger.log(
+      `Duplicate skipped — Linear issue ${existing.identifier} already exists with title "${existing.title}"`
+    );
+    return existing.identifier;
   }
 
   // Get team ID, label IDs, project ID, and active cycle in one query


### PR DESCRIPTION
Implements the Definition-of-Done sibling sweep for AI-4108.

## Context

PR #129 fixed duplicate Linear issue creation in the **feedback clustering pipeline**. AI-4108's fix is already live. This PR extends the same dedup guard to the two other Linear \`issueCreate\` callsites so the class of bug is fully closed.

## Sibling callsites fixed

1. \`trigger/sahara-whatsapp-monitor.ts::createLinearIssue\` — scheduled task detects actionable themes from WhatsApp and creates Linear issues. Without a dedup check, the same theme detected across runs spawned duplicates.
2. \`app/api/bug-report/route.ts::createLinearBugIssue\` — in-app bug-report widget. A double-click / retry would create duplicate issues.

## Changes

- **\`lib/feedback/linear-auto-triage.ts\`**: export \`findExistingLinearIssue\` (was private) so siblings can reuse the same exact-title match helper.
- **\`trigger/sahara-whatsapp-monitor.ts\`**: check before \`issueCreate\`; if match found, return the existing identifier and log the skip.
- **\`app/api/bug-report/route.ts\`**: check before \`issueCreate\`; if match found, return the existing issue as if creation succeeded (user-facing idempotency).

## Verification

- \`tsc --noEmit\` — clean, 0 errors
- \`vitest lib/feedback/__tests__/clustering.test.ts\` — 13 passed
- Sibling grep: \`grep -rn 'issueCreate' --include='*.ts'\` — only 3 callsites total, all now dedup-guarded

## Definition of Done for AI-4108

- [x] PR #129 merged — dedup at feedback-insight layer
- [x] Deployed to prod (Vercel build success on merge commit a97bf4c)
- [x] Live-verified — fix present in deployed bundle
- [x] Sibling sweep — this PR

Linear: AI-4108