### PR TITLE
chore: drop u.joinsahara.com references

### DIFF
--- a/app/api/funnel/checkout/route.ts
+++ b/app/api/funnel/checkout/route.ts
@@ -5,7 +5,7 @@ import { corsHeaders, handleCorsOptions } from "@/lib/api/cors";
 
 /**
  * POST /api/funnel/checkout
- * Create Stripe checkout session for the funnel (u.joinsahara.com).
+ * Create Stripe checkout session for the legacy funnel (you.joinsahara.com).
  *
  * Unlike the main checkout route, this does NOT require authentication.
  * The funnel is a static Vite app where users may not have accounts yet.
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
     }
 
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://joinsahara.com";
-    const funnelUrl = process.env.NEXT_PUBLIC_FUNNEL_URL || "https://u.joinsahara.com";
+    const funnelUrl = process.env.NEXT_PUBLIC_FUNNEL_URL || "https://you.joinsahara.com";
 
     // After successful checkout, redirect to main app onboarding with success flag.
     // After cancellation, redirect back to the funnel.

--- a/app/api/funnel/reconcile/route.ts
+++ b/app/api/funnel/reconcile/route.ts
@@ -14,7 +14,7 @@ import Stripe from "stripe";
  * Links a funnel Stripe checkout session to an authenticated user.
  *
  * Flow:
- * 1. User pays on funnel (u.joinsahara.com) → Stripe checkout with userId "funnel-pending"
+ * 1. User pays on funnel (you.joinsahara.com) → Stripe checkout with userId "funnel-pending"
  * 2. User is redirected to main app onboarding with session_id in URL
  * 3. User creates account / logs in on main app
  * 4. Frontend calls this endpoint with the session_id to link the subscription

--- a/app/api/funnel/sync/route.ts
+++ b/app/api/funnel/sync/route.ts
@@ -4,7 +4,7 @@ import { corsHeaders, handleCorsOptions } from "@/lib/api/cors";
 
 /**
  * POST /api/funnel/sync
- * Receives funnel data (chat messages + journey progress) from u.joinsahara.com.
+ * Receives funnel data (chat messages + journey progress) from you.joinsahara.com.
  *
  * Stores data in funnel_sessions table keyed by sessionId.
  * When a user signs up for the full platform, this data is used to pre-populate

--- a/components/welcome-back-banner.tsx
+++ b/components/welcome-back-banner.tsx
@@ -4,7 +4,7 @@
  * WelcomeBackBanner
  *
  * One-time banner shown when a visitor arrives via the redirect from the
- * legacy u.joinsahara.com subdomain. Reassures them that their account
+ * legacy you.joinsahara.com subdomain. Reassures them that their account
  * migrated cleanly and points them at the password-reset flow if they
  * can't sign in.
  *

--- a/lib/api/cors.ts
+++ b/lib/api/cors.ts
@@ -4,7 +4,6 @@ const ALLOWED_ORIGINS = new Set([
   process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
   "http://localhost:3000",
   "http://localhost:3001",
-  "https://u.joinsahara.com",
   "http://localhost:5173",
 ]);
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -53,11 +53,7 @@ export async function middleware(request: NextRequest) {
   const host = (request.headers.get("host") || "").toLowerCase();
   if (
     host === "you.joinsahara.com" ||
-    host.startsWith("you.joinsahara.com:") ||
-    // keep the old (unused) subdomain supported too in case it ever gets
-    // DNS; costs nothing and covers both references in the old changelog.
-    host === "u.joinsahara.com" ||
-    host.startsWith("u.joinsahara.com:")
+    host.startsWith("you.joinsahara.com:")
   ) {
     const target = new URL(pathname, "https://www.joinsahara.com");
     // Preserve the original query string.


### PR DESCRIPTION
## Summary
- Remove `u.joinsahara.com` from middleware host-redirect block — DNS is dead, no traffic reaches us there, so no need for the defensive redirect.
- Remove `u.joinsahara.com` from CORS allowed origins.
- Swap `u.joinsahara.com` fallback -> `you.joinsahara.com` in `/api/funnel/checkout` (that's the live legacy funnel now).
- Update docstrings in `funnel/sync`, `funnel/reconcile`, and `welcome-back-banner` comment.

## Why
`you.joinsahara.com` is still the live legacy Vite/Firebase funnel. `u.joinsahara.com` was a parallel subdomain that never ended up in production — it has no DNS record and shouldn't be in our allowed origins or fallback defaults.

## Test plan
- [x] `npm run build` passes (all 70+ routes compiled, middleware bundles correctly)
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` on all changed files clean (only pre-existing warning in welcome-back-banner)
- [x] `npx vitest run` — only pre-existing failures in `lib/hooks/__tests__/use-whisper-flow.test.ts` (unrelated to this change; file was not touched)
- [x] Mirrored middleware host-check logic in a standalone node script — `you.joinsahara.com` still redirects, `u.joinsahara.com` is ignored as expected
- [ ] Post-deploy: `curl -I https://you.joinsahara.com/` should still 308 to `https://www.joinsahara.com/` (requires domain move on Vercel — separate task)

Note: this PR does not reattach `you.joinsahara.com` to this Vercel project — that's a dashboard operation. Once that happens, the middleware redirect begins firing and consolidates the funnel traffic onto www.

🤖 Generated with [Claude Code](https://claude.com/claude-code)