### PR TITLE
fix(auth): password reset link 404 bug (blocks migrated users)

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -50,8 +50,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(errorUrl)
   }
 
-  // If no code provided, redirect to forgot-password with error hint
-  const errorUrl = new URL("/forgot-password", origin)
-  errorUrl.searchParams.set("error", "expired")
-  return NextResponse.redirect(errorUrl)
+  // No `code` param. This happens when Supabase is configured for the
+  // implicit flow (legacy default) and delivers the session as a URL
+  // fragment (#access_token=...&refresh_token=...). Fragments are not
+  // sent to the server, so we redirect to `next` and let the browser
+  // carry the fragment over; the client-side Supabase SDK on the
+  // destination page picks it up via `detectSessionInUrl`.
+  return NextResponse.redirect(new URL(next, origin))
 }

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -4,7 +4,15 @@ import { clientEnv } from "@/lib/env";
 export function createClient() {
   return createBrowserClient(
     clientEnv.NEXT_PUBLIC_SUPABASE_URL,
-    clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+    {
+      auth: {
+        flowType: "pkce",
+        detectSessionInUrl: true,
+        autoRefreshToken: true,
+        persistSession: true,
+      },
+    }
   );
 }
 

--- a/scripts/migrations/firebase-to-supabase/import-users.ts
+++ b/scripts/migrations/firebase-to-supabase/import-users.ts
@@ -180,9 +180,13 @@ async function importUser(
     return { status: "error", reason: `profile upsert: ${profileErr.message}` };
   }
 
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.joinsahara.com";
   const { error: linkErr } = await db.auth.admin.generateLink({
     type: "recovery",
     email: fbUser.email,
+    options: {
+      redirectTo: `${siteUrl}/api/auth/callback?next=/reset-password`,
+    },
   });
   if (linkErr) {
     console.warn(`  reset link failed for ${fbUser.email}: ${linkErr.message}`);


### PR DESCRIPTION
## Summary

Fred and Bill both reported today that clicking the password-reset email link produces a 404 after yesterday's Firebase -> Supabase migration. Root cause: Supabase's `/auth/v1/verify` endpoint returns session tokens in the URL fragment (`#access_token=...&refresh_token=...`), but the `/api/auth/callback` route only handled the PKCE `?code=` query param and redirected to `/forgot-password?error=expired` on miss. URL fragments are client-side only and never reach the server.

## Changes

- `app/api/auth/callback/route.ts`: on no-code, redirect to `next` (default `/reset-password`) instead of `/forgot-password?error=expired`. Browsers preserve the fragment across redirects, so the client-side Supabase SDK picks up the session on the destination page.
- `lib/supabase/client.ts`: enable PKCE flow on the browser client so future reset links use `?code=` (cleaner, server-exchangeable) rather than fragment-only implicit flow.
- `scripts/migrations/firebase-to-supabase/import-users.ts`: pass `redirectTo` so admin-generated recovery links land on `/api/auth/callback?next=/reset-password` instead of the bare site root.

## Test plan

- [ ] Deploy preview (Vercel)
- [ ] Click existing recovery link on preview URL -> lands on `/reset-password` with session (not 404, not expired error)
- [ ] `/forgot-password` -> email -> click -> `/reset-password` -> set new password -> login
- [ ] Re-dispatch recovery emails for all 65 migrated users once merged
- [ ] Confirm Fred and Bill can reset

## Context

- Linear: AI-8485 follow-up
- PRs: #156 (migration runbook), #157 (executed migration)
- Affected users: 65 Firebase-migrated + anyone using `/forgot-password` today

🤖 Generated with [Claude Code](https://claude.com/claude-code)