### PR TITLE
fix(auth): auth-aware navbar + redirect authed users off auth entry pages

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -26,12 +26,15 @@ import Image from "next/image";
 import { useState, useEffect, memo } from "react";
 import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
+import { getSupabaseClient } from "@/lib/supabase/client";
 
 function NavBar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
   const pathname = usePathname();
   const isDashboard = pathname?.startsWith("/dashboard");
+  const showAuthedNav = isDashboard || isAuthenticated;
 
   // Hide NavBar on pages that have their own full-screen layouts/headers
   // - /chat has its own header with "Talk to Fred" and back button
@@ -49,6 +52,17 @@ function NavBar() {
     };
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    const supabase = getSupabaseClient();
+    supabase.auth.getSession().then((result: { data: { session: unknown | null } }) => {
+      setIsAuthenticated(!!result.data.session);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event: string, session: unknown | null) => {
+      setIsAuthenticated(!!session);
+    });
+    return () => sub.subscription.unsubscribe();
   }, []);
 
   const menuItems = [
@@ -176,7 +190,7 @@ function NavBar() {
 
                 <Separator className="my-2 bg-gray-200 dark:bg-gray-800" />
 
-                {isDashboard ? (
+                {showAuthedNav ? (
                   <Button asChild size="lg" className="w-full touch-target bg-[#ff6a1a] hover:bg-[#ea580c] text-white border-0 shadow-lg shadow-[#ff6a1a]/25">
                     <Link href="/dashboard" onClick={() => setIsMenuOpen(false)}>
                       Dashboard
@@ -273,7 +287,7 @@ function NavBar() {
 
           {/* Right Actions */}
           <div className="flex items-center space-x-2 sm:space-x-3">
-            {isDashboard ? (
+            {showAuthedNav ? (
               <Button
                 asChild
                 className="hidden sm:flex bg-[#ff6a1a] hover:bg-[#ea580c] text-white border-0 shadow-lg shadow-[#ff6a1a]/25 hover:shadow-[#ff6a1a]/40 transition-all duration-300 touch-target"
@@ -288,7 +302,7 @@ function NavBar() {
                 <Button
                   asChild
                   variant="outline"
-                  className="hidden sm:flex border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-[#ff6a1a] hover:text-[#ff6a1a] transition-all duration-300 touch-target"
+                  className="flex border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:border-[#ff6a1a] hover:text-[#ff6a1a] transition-all duration-300 touch-target"
                   size="sm"
                 >
                   <Link href="/login">

--- a/middleware.ts
+++ b/middleware.ts
@@ -115,6 +115,30 @@ export async function middleware(request: NextRequest) {
       return redirectResponse;
     }
 
+    // Authenticated users hitting auth entry pages (/login, /signup, /get-started)
+    // should be routed onward. Without this, the navbar "Login" button and any
+    // stale-tab navigation drops them back onto the signup wizard or login form,
+    // which is confusing and can produce duplicate-account errors.
+    const authEntryPaths = ["/login", "/signup", "/get-started"];
+    const isAuthEntry = authEntryPaths.some(
+      (p) => pathname === p || pathname.startsWith(`${p}/`)
+    );
+    if (user && isAuthEntry) {
+      const rawRedirect = request.nextUrl.searchParams.get("redirect");
+      const safeRedirect =
+        rawRedirect &&
+        rawRedirect.startsWith("/") &&
+        !rawRedirect.startsWith("//") &&
+        !rawRedirect.includes("\\") &&
+        !rawRedirect.includes("://")
+          ? rawRedirect
+          : "/dashboard";
+      const target = new URL(safeRedirect, request.url);
+      const redirectResponse = NextResponse.redirect(target);
+      redirectResponse.headers.set("X-Request-ID", requestId);
+      return redirectResponse;
+    }
+
     // Phase 77-02: Welcome flow enforcement
     // Redirect authenticated users who haven't completed intake to /welcome
     const welcomeExemptPaths = ['/welcome', '/api/', '/login', '/signup', '/get-started', '/onboarding', '/_next/', '/favicon']


### PR DESCRIPTION
## Summary
- Browserbase walkthrough of `/get-started` -> signup -> `/welcome` flow surfaced that the header navbar shows "Login" + "Get Started Free" to already-authenticated users on every non-dashboard page, because `NavBar` used `pathname.startsWith("/dashboard")` as a proxy for auth state.
- Clicking the stale "Login" button drops an authed user onto `/login`, which also does not redirect them. Repeat signup attempts raised `An account with this email already exists` which some migrated users read as a broken account.
- Fix: subscribe the navbar to the Supabase session and use a true `showAuthedNav` flag; add a middleware redirect that sends authed users hitting `/login`, `/signup`, or `/get-started` to `/dashboard` (honoring a safe `?redirect=` param).

## Test plan
- [x] `npx tsc --noEmit` clean on changed files
- [x] Playwright CLI walkthrough: stage select -> challenge select -> signup -> `/welcome` still works (prod repro pre-fix)
- [ ] Preview deploy re-walkthrough:
  - [ ] Logged-out user still sees Login + Get Started Free in header
  - [ ] Logged-out user can sign up via `/get-started` end-to-end
  - [ ] Signed-in user sees Dashboard button in header
  - [ ] Signed-in user hitting `/login` redirects to `/dashboard`
  - [ ] Signed-in user hitting `/get-started` redirects to `/dashboard`
  - [ ] `/login?redirect=/dashboard/chat` still honors the redirect for unauthed users

🤖 Generated with [Claude Code](https://claude.com/claude-code)