### PR TITLE
feat(admin): users directory + magic-link impersonation

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -29,6 +29,12 @@ export default async function AdminLayout({
               Dashboard
             </Link>
             <Link
+              href="/admin/users"
+              className="px-4 py-2 text-sm font-medium rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            >
+              Users
+            </Link>
+            <Link
               href="/admin/prompts"
               className="px-4 py-2 text-sm font-medium rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
             >

--- a/app/admin/users/[id]/page.tsx
+++ b/app/admin/users/[id]/page.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useEffect, useState, use } from "react";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft } from "lucide-react";
+
+interface Detail {
+  profile: Record<string, unknown> | null;
+  auth: {
+    id: string;
+    email: string | null;
+    last_sign_in_at: string | null;
+    recovery_sent_at: string | null;
+    email_confirmed_at: string | null;
+    created_at: string;
+    user_metadata?: Record<string, unknown>;
+  } | null;
+  stats: {
+    chat_messages: number;
+    journey_events: number;
+    fred_steps: number;
+  };
+  recent: {
+    chat: Array<{ id: string; role: string; content: string; created_at: string }>;
+    journey: Array<{ event_type: string; metadata?: Record<string, unknown>; created_at: string }>;
+  };
+}
+
+const CORE_PROFILE_FIELDS: Array<{ key: string; label: string }> = [
+  { key: "name", label: "Name" },
+  { key: "email", label: "Email" },
+  { key: "company_name", label: "Company" },
+  { key: "product_positioning", label: "Product positioning" },
+  { key: "oases_stage", label: "Oases stage" },
+  { key: "stage", label: "Stage" },
+  { key: "industry", label: "Industry" },
+  { key: "team_size", label: "Team size" },
+  { key: "revenue_range", label: "Revenue" },
+  { key: "funding_history", label: "Funding" },
+  { key: "traction", label: "Traction" },
+  { key: "product_status", label: "Product status" },
+  { key: "ninety_day_goal", label: "90-day goal" },
+  { key: "primary_constraint", label: "Primary constraint" },
+  { key: "co_founder", label: "Co-founder" },
+  { key: "reality_lens_score", label: "Reality Lens score" },
+];
+
+export default function UserDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const [data, setData] = useState<Detail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [impersonating, setImpersonating] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/admin/users/${id}`);
+        if (!res.ok) throw new Error(`${res.status}`);
+        setData(await res.json());
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load");
+      }
+    }
+    load();
+  }, [id]);
+
+  async function impersonate() {
+    setImpersonating(true);
+    try {
+      const res = await fetch(`/api/admin/users/${id}/impersonate`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || `${res.status}`);
+      window.open(json.action_link, "_blank", "noopener,noreferrer");
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Failed to impersonate");
+    } finally {
+      setImpersonating(false);
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <Link href="/admin/users"><Button variant="ghost" size="sm" className="gap-1"><ArrowLeft className="h-4 w-4" />Back</Button></Link>
+        <Card className="border-red-500"><CardContent className="pt-6 text-red-600">Error: {error}</CardContent></Card>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-10 w-40" />
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  const profile = (data.profile || {}) as Record<string, unknown>;
+  const md = data.auth?.user_metadata || {};
+  const firebaseRaw = (profile.enrichment_data as Record<string, unknown> | undefined)?.firebase_raw;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex justify-between items-start">
+        <div>
+          <Link href="/admin/users"><Button variant="ghost" size="sm" className="gap-1 mb-2"><ArrowLeft className="h-4 w-4" />All users</Button></Link>
+          <h2 className="text-2xl font-bold">{(profile.name as string) || data.auth?.email || id}</h2>
+          <p className="text-gray-600 dark:text-gray-400">{data.auth?.email}</p>
+        </div>
+        <Button onClick={impersonate} disabled={impersonating} className="bg-[#ff6a1a] hover:bg-[#ea580c]">
+          {impersonating ? "Generating link…" : "Log in as this user"}
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Card><CardHeader className="pb-1"><CardDescription>Chat messages</CardDescription></CardHeader>
+          <CardContent><div className="text-2xl font-bold">{data.stats.chat_messages}</div></CardContent></Card>
+        <Card><CardHeader className="pb-1"><CardDescription>Journey events</CardDescription></CardHeader>
+          <CardContent><div className="text-2xl font-bold">{data.stats.journey_events}</div></CardContent></Card>
+        <Card><CardHeader className="pb-1"><CardDescription>Fred step progress</CardDescription></CardHeader>
+          <CardContent><div className="text-2xl font-bold">{data.stats.fred_steps}</div></CardContent></Card>
+        <Card><CardHeader className="pb-1"><CardDescription>Last sign-in</CardDescription></CardHeader>
+          <CardContent><div className="text-sm">{data.auth?.last_sign_in_at ? new Date(data.auth.last_sign_in_at).toLocaleString() : <span className="text-gray-400">never</span>}</div></CardContent></Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Profile</CardTitle>
+          <CardDescription>
+            Source:{" "}
+            {(md.imported_from as string) === "firebase" ? (
+              <Badge className="bg-orange-100 text-orange-800 hover:bg-orange-100">firebase-migrated</Badge>
+            ) : (
+              <Badge variant="outline">native</Badge>
+            )}
+            {md.firebase_uid ? <span className="ml-2 text-xs text-gray-500">fb_uid: {String(md.firebase_uid)}</span> : null}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3">
+            {CORE_PROFILE_FIELDS.map(({ key, label }) => {
+              const v = profile[key];
+              return (
+                <div key={key}>
+                  <dt className="text-xs uppercase tracking-wide text-gray-500">{label}</dt>
+                  <dd className="text-sm mt-0.5">{v !== null && v !== undefined && v !== "" ? String(v) : <span className="text-gray-400">—</span>}</dd>
+                </div>
+              );
+            })}
+          </dl>
+        </CardContent>
+      </Card>
+
+      {firebaseRaw ? (
+        <Card>
+          <CardHeader><CardTitle>Firebase snapshot (preserved)</CardTitle>
+            <CardDescription>Original Firestore doc at time of migration — lossless audit trail.</CardDescription></CardHeader>
+          <CardContent>
+            <pre className="text-xs bg-gray-50 dark:bg-gray-900 p-3 rounded overflow-x-auto">{JSON.stringify(firebaseRaw, null, 2)}</pre>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader><CardTitle>Recent journey events</CardTitle></CardHeader>
+        <CardContent>
+          {data.recent.journey.length === 0 ? (
+            <p className="text-sm text-gray-400">No journey events yet.</p>
+          ) : (
+            <ul className="space-y-2">
+              {data.recent.journey.map((e, i) => (
+                <li key={i} className="text-sm border-l-2 border-[#ff6a1a] pl-3">
+                  <div className="font-medium">{e.event_type}</div>
+                  <div className="text-xs text-gray-500">{new Date(e.created_at).toLocaleString()}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader><CardTitle>Recent chat messages</CardTitle></CardHeader>
+        <CardContent>
+          {data.recent.chat.length === 0 ? (
+            <p className="text-sm text-gray-400">No chat activity.</p>
+          ) : (
+            <ul className="space-y-3">
+              {data.recent.chat.map((m) => (
+                <li key={m.id} className="text-sm">
+                  <div className="flex items-center gap-2 mb-1">
+                    <Badge variant={m.role === "user" ? "default" : "outline"}>{m.role}</Badge>
+                    <span className="text-xs text-gray-500">{new Date(m.created_at).toLocaleString()}</span>
+                  </div>
+                  <p className="pl-2 border-l-2 border-gray-200 dark:border-gray-700">{m.content.slice(0, 400)}{m.content.length > 400 ? "…" : ""}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface AdminUser {
+  id: string;
+  email: string | null;
+  name: string | null;
+  company_name: string | null;
+  oases_stage: string | null;
+  stage: string | null;
+  tier: number | null;
+  reality_lens_complete: boolean | null;
+  reality_lens_score: number | null;
+  enrichment_source: string | null;
+  updated_at: string | null;
+  auth: {
+    last_sign_in_at: string | null;
+    recovery_sent_at: string | null;
+    email_confirmed_at: string | null;
+    imported_from: string | null;
+    firebase_uid: string | null;
+  } | null;
+}
+
+type SourceFilter = "all" | "firebase" | "native" | "test";
+
+function classifyTest(email: string | null): boolean {
+  if (!email) return false;
+  const e = email.toLowerCase();
+  const fakes = [
+    "eeeee@e.com",
+    "iii@jjjj.co",
+    "gg@g.com",
+    "i@qasfdq.com",
+    "dumb@dumber.com",
+    "dev@test.com",
+    "james@test.com",
+    "browser.test.2@example.com",
+    "n2938f@yahoo.com",
+  ];
+  if (fakes.includes(e)) return true;
+  const patterns = [
+    /^qa-/,
+    /^test-/,
+    /^test\+/,
+    /^deploy-verify/,
+    /^bug-test/,
+    /^ux-?audit/,
+    /^uxtest/,
+    /^stagehand-test/,
+    /^debugtest/,
+    /^chatbot-test/,
+    /^v7test/,
+    /^testfounder/,
+    /^testuser/,
+    /^tester_/,
+    /^timm@test\.com$/,
+    /^uitest/,
+    /^john@test\.con$/,
+    /^test_random/,
+    /^jjjj@j\.com$/,
+    /^jjjames/,
+    /^joe@blow\.com$/,
+    /@example\.com$/,
+    /@test\.(com|dev)$/,
+    /@test-sahara\.com$/,
+    /@sahara-testing/,
+    /@thewizzardof\.ai/,
+    /@test\.joinsahara\.com$/,
+    /@sahara-test\.com$/,
+    /@testmail\.com$/,
+    /@acrobatics\.dev$/,
+  ];
+  return patterns.some((p) => p.test(e));
+}
+
+export default function AdminUsersPage() {
+  const [users, setUsers] = useState<AdminUser[] | null>(null);
+  const [query, setQuery] = useState("");
+  const [sourceFilter, setSourceFilter] = useState<SourceFilter>("all");
+  const [error, setError] = useState<string | null>(null);
+  const [impersonating, setImpersonating] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("/api/admin/users?limit=500");
+        if (!res.ok) throw new Error(`${res.status}`);
+        const json = await res.json();
+        setUsers(json.users || []);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load");
+      }
+    }
+    load();
+  }, []);
+
+  const counts = useMemo(() => {
+    const all = users || [];
+    return {
+      total: all.length,
+      firebase: all.filter((u) => u.auth?.imported_from === "firebase").length,
+      native: all.filter((u) => !u.auth?.imported_from && !classifyTest(u.email)).length,
+      test: all.filter((u) => classifyTest(u.email)).length,
+    };
+  }, [users]);
+
+  const visible = useMemo(() => {
+    if (!users) return [];
+    const q = query.trim().toLowerCase();
+    return users.filter((u) => {
+      if (sourceFilter === "firebase" && u.auth?.imported_from !== "firebase") return false;
+      if (sourceFilter === "native" && (u.auth?.imported_from || classifyTest(u.email))) return false;
+      if (sourceFilter === "test" && !classifyTest(u.email)) return false;
+      if (!q) return true;
+      const hay = `${u.email || ""} ${u.name || ""} ${u.company_name || ""}`.toLowerCase();
+      return hay.includes(q);
+    });
+  }, [users, query, sourceFilter]);
+
+  async function impersonate(userId: string) {
+    setImpersonating(userId);
+    try {
+      const res = await fetch(`/api/admin/users/${userId}/impersonate`, { method: "POST" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || `${res.status}`);
+      window.open(json.action_link, "_blank", "noopener,noreferrer");
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "Failed to impersonate");
+    } finally {
+      setImpersonating(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Users</h2>
+        <p className="text-gray-600 dark:text-gray-400 mt-1">
+          All Sahara users: internal team, paying founders, and migrated Firebase accounts.
+          Click &quot;Log in as&quot; to view the product through a specific user&apos;s account
+          via a Supabase magic link (opens in a new tab; your admin session is preserved).
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <Card><CardHeader className="pb-1"><CardDescription>Total</CardDescription></CardHeader>
+          <CardContent><div className="text-2xl font-bold">{counts.total}</div></CardContent></Card>
+        <Card><CardHeader className="pb-1"><CardDescription>Firebase-migrated</CardDescription></CardHeader>
+          <CardContent><div className="text-2xl font-bold text-[#ff6a1a]">{counts.firebase}</div></CardContent></Card>
+        <Card><CardHeader className="pb-1"><CardDescription>Real (Supabase-native)</CardDescription></CardHeader>
+          <CardContent><div className="text-2xl font-bold">{counts.native}</div></CardContent></Card>
+        <Card><CardHeader className="pb-1"><CardDescription>Test / internal</CardDescription></CardHeader>
+          <CardContent><div className="text-2xl font-bold text-gray-400">{counts.test}</div></CardContent></Card>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-2">
+        <Input
+          placeholder="Search email, name, or company"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="max-w-sm"
+        />
+        <div className="flex gap-2">
+          {(["all", "firebase", "native", "test"] as const).map((f) => (
+            <Button
+              key={f}
+              variant={sourceFilter === f ? "default" : "outline"}
+              size="sm"
+              onClick={() => setSourceFilter(f)}
+            >
+              {f}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <Card className="border-red-500">
+          <CardContent className="pt-6 text-red-600 dark:text-red-400">Error: {error}</CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{visible.length} of {counts.total} users</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!users ? (
+            <div className="space-y-2">
+              {Array.from({ length: 10 }).map((_, i) => <Skeleton key={i} className="h-10 w-full" />)}
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>User</TableHead>
+                    <TableHead>Company</TableHead>
+                    <TableHead>Stage</TableHead>
+                    <TableHead>Source</TableHead>
+                    <TableHead>Reality Lens</TableHead>
+                    <TableHead>Last sign-in</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {visible.map((u) => (
+                    <TableRow key={u.id}>
+                      <TableCell>
+                        <div className="font-medium">{u.name || "—"}</div>
+                        <div className="text-xs text-gray-500">{u.email}</div>
+                      </TableCell>
+                      <TableCell>{u.company_name || <span className="text-gray-400">—</span>}</TableCell>
+                      <TableCell>
+                        {u.oases_stage ? <Badge variant="outline">{u.oases_stage}</Badge> : <span className="text-gray-400">—</span>}
+                      </TableCell>
+                      <TableCell>
+                        {u.auth?.imported_from === "firebase" ? (
+                          <Badge className="bg-orange-100 text-orange-800 hover:bg-orange-100">firebase</Badge>
+                        ) : classifyTest(u.email) ? (
+                          <Badge variant="secondary">test</Badge>
+                        ) : (
+                          <Badge variant="outline">native</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {u.reality_lens_complete ? (
+                          <Badge className="bg-green-100 text-green-800 hover:bg-green-100">{u.reality_lens_score ?? "done"}</Badge>
+                        ) : (
+                          <span className="text-gray-400">—</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {u.auth?.last_sign_in_at
+                          ? new Date(u.auth.last_sign_in_at).toLocaleString()
+                          : <span className="text-gray-400">never</span>}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-2">
+                          <Link href={`/admin/users/${u.id}`}>
+                            <Button variant="outline" size="sm">View</Button>
+                          </Link>
+                          <Button
+                            variant="default"
+                            size="sm"
+                            disabled={impersonating === u.id}
+                            onClick={() => impersonate(u.id)}
+                            className="bg-[#ff6a1a] hover:bg-[#ea580c]"
+                          >
+                            {impersonating === u.id ? "…" : "Log in as"}
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/api/admin/users/[id]/impersonate/route.ts
+++ b/app/api/admin/users/[id]/impersonate/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminRequest } from "@/lib/auth/admin";
+import { createServiceClient } from "@/lib/supabase/server";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = await requireAdminRequest(request);
+  if (denied) return denied;
+
+  const { id } = await params;
+  const supabase = createServiceClient();
+
+  const { data: authUser, error: aErr } = await supabase.auth.admin.getUserById(id);
+  if (aErr || !authUser?.user?.email) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  const origin = request.nextUrl.origin;
+  const { data, error } = await supabase.auth.admin.generateLink({
+    type: "magiclink",
+    email: authUser.user.email,
+    options: {
+      redirectTo: `${origin}/dashboard`,
+    },
+  });
+
+  if (error || !data?.properties?.action_link) {
+    return NextResponse.json(
+      { error: error?.message || "Failed to generate link" },
+      { status: 500 },
+    );
+  }
+
+  console.log(
+    `[admin.impersonate] magic link issued for user=${id} email=${authUser.user.email}`,
+  );
+
+  return NextResponse.json({
+    email: authUser.user.email,
+    action_link: data.properties.action_link,
+  });
+}

--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminRequest } from "@/lib/auth/admin";
+import { createServiceClient } from "@/lib/supabase/server";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = await requireAdminRequest(request);
+  if (denied) return denied;
+
+  const { id } = await params;
+  const supabase = createServiceClient();
+
+  const [{ data: profile, error: pErr }, { data: authUser }] = await Promise.all([
+    supabase.from("profiles").select("*").eq("id", id).single(),
+    supabase.auth.admin.getUserById(id),
+  ]);
+
+  if (pErr && pErr.code !== "PGRST116") {
+    return NextResponse.json({ error: pErr.message }, { status: 500 });
+  }
+
+  const [
+    { count: chatCount },
+    { count: journeyCount },
+    { count: stepCount },
+    { data: recentChat },
+    { data: recentJourney },
+  ] = await Promise.all([
+    supabase.from("chat_messages").select("id", { count: "exact", head: true }).eq("user_id", id),
+    supabase.from("journey_events").select("id", { count: "exact", head: true }).eq("user_id", id),
+    supabase.from("fred_step_progress").select("id", { count: "exact", head: true }).eq("user_id", id),
+    supabase.from("chat_messages").select("id, role, content, created_at").eq("user_id", id).order("created_at", { ascending: false }).limit(10),
+    supabase.from("journey_events").select("event_type, metadata, created_at").eq("user_id", id).order("created_at", { ascending: false }).limit(10),
+  ]);
+
+  return NextResponse.json({
+    profile,
+    auth: authUser?.user
+      ? {
+          id: authUser.user.id,
+          email: authUser.user.email,
+          last_sign_in_at: authUser.user.last_sign_in_at,
+          recovery_sent_at: authUser.user.recovery_sent_at,
+          email_confirmed_at: authUser.user.email_confirmed_at,
+          created_at: authUser.user.created_at,
+          user_metadata: authUser.user.user_metadata,
+        }
+      : null,
+    stats: {
+      chat_messages: chatCount || 0,
+      journey_events: journeyCount || 0,
+      fred_steps: stepCount || 0,
+    },
+    recent: {
+      chat: recentChat || [],
+      journey: recentJourney || [],
+    },
+  });
+}

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminRequest } from "@/lib/auth/admin";
+import { createServiceClient } from "@/lib/supabase/server";
+
+export async function GET(request: NextRequest) {
+  const denied = await requireAdminRequest(request);
+  if (denied) return denied;
+
+  const { searchParams } = new URL(request.url);
+  const q = (searchParams.get("q") || "").trim().toLowerCase();
+  const limit = Math.min(parseInt(searchParams.get("limit") || "200", 10), 500);
+
+  const supabase = createServiceClient();
+
+  interface ProfileRow {
+    id: string;
+    email: string | null;
+    name: string | null;
+    company_name: string | null;
+    oases_stage: string | null;
+    stage: string | null;
+    industry: string | null;
+    tier: number | null;
+    product_positioning: string | null;
+    reality_lens_complete: boolean | null;
+    reality_lens_score: number | null;
+    enrichment_source: string | null;
+    primary_constraint: string | null;
+    ninety_day_goal: string | null;
+    traction: string | null;
+    product_status: string | null;
+    revenue_range: string | null;
+    team_size: number | null;
+    funding_history: unknown;
+    co_founder: string | null;
+    created_at: string | null;
+    updated_at: string | null;
+  }
+
+  const { data: rawProfiles, error } = await supabase
+    .from("profiles")
+    .select("*")
+    .order("updated_at", { ascending: false, nullsFirst: false })
+    .limit(limit);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  let profiles = (rawProfiles || []) as unknown as ProfileRow[];
+
+  if (q) {
+    profiles = profiles.filter((p) => {
+      const hay = `${p.email || ""} ${p.name || ""} ${p.company_name || ""}`.toLowerCase();
+      return hay.includes(q);
+    });
+  }
+
+  const { data: authList } = await supabase.auth.admin.listUsers({ perPage: 500 });
+  const authByEmail = new Map<string, {
+    last_sign_in_at: string | null;
+    recovery_sent_at: string | null;
+    email_confirmed_at: string | null;
+    imported_from: string | null;
+    firebase_uid: string | null;
+    provider: string;
+  }>();
+  for (const u of authList?.users || []) {
+    if (!u.email) continue;
+    const md = (u.user_metadata as Record<string, unknown>) || {};
+    authByEmail.set(u.email.toLowerCase(), {
+      last_sign_in_at: u.last_sign_in_at || null,
+      recovery_sent_at: u.recovery_sent_at || null,
+      email_confirmed_at: u.email_confirmed_at || null,
+      imported_from: (md.imported_from as string) || null,
+      firebase_uid: (md.firebase_uid as string) || null,
+      provider: (u.app_metadata?.provider as string) || "email",
+    });
+  }
+
+  const merged = profiles.map((p) => ({
+    ...p,
+    auth: p.email ? authByEmail.get(p.email.toLowerCase()) || null : null,
+  }));
+
+  return NextResponse.json({
+    total: merged.length,
+    users: merged,
+  });
+}


### PR DESCRIPTION
## Summary
Adds /admin/users so the team can see every user in the system (internal + Firebase-migrated + Supabase-native) and log in as any user in a new tab to spot-check the product from their POV. Requested by Fred post-migration.

## What's in it
- **GET /api/admin/users** - list + search + filter, joins auth.users so you see last_sign_in_at, recovery_sent_at, imported_from
- **GET /api/admin/users/[id]** - single-user detail with chat_messages / journey_events / fred_step_progress counts + last 10 events of each
- **POST /api/admin/users/[id]/impersonate** - one-time Supabase magic link (type=magiclink), admin session preserved in original tab, auditable via Supabase auth logs
- **/admin/users** page - 4 stat cards (total / firebase / native / test), search, source filter, "Log in as" button per row
- **/admin/users/[id]** detail - full profile, Firebase raw snapshot if present, journey + chat timelines, "Log in as" CTA
- Nav link added to admin top bar

## Test plan
- [ ] /admin/users loads, stat counts match DB
- [ ] Search narrows list by email / name / company
- [ ] Source filter works (all / firebase / native / test)
- [ ] Bill Hood (billhoodtaos@gmail.com) detail shows AI Replicas, Taos NM, reality_lens_score=65, firebase_raw blob
- [ ] "Log in as" opens new tab signed in as target user
- [ ] Admin's original tab remains the admin UI after impersonation

## Notes
- Admin auth bypass (AI-3516) still enabled globally; gating returns automatically when bypass is removed
- biggest_challenge -> challenges (jsonb column) persistence needs a separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)