### PR TITLE
fix(navbar): don't blank the page when Supabase env is unset

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -55,7 +55,16 @@ function NavBar() {
   }, []);
 
   useEffect(() => {
-    const supabase = getSupabaseClient();
+    // Fail closed (logged-out) if Supabase env isn't configured on this deploy
+    // (e.g. preview branches without NEXT_PUBLIC_SUPABASE_* set). Throwing here
+    // bubbles to global-error.tsx and blanks the whole page.
+    let supabase: ReturnType<typeof getSupabaseClient>;
+    try {
+      supabase = getSupabaseClient();
+    } catch {
+      setIsAuthenticated(false);
+      return;
+    }
     supabase.auth.getSession().then((result: { data: { session: unknown | null } }) => {
       setIsAuthenticated(!!result.data.session);
     });


### PR DESCRIPTION
## Summary
- Follow-up to #171. The navbar's new useEffect calls `getSupabaseClient()` on every page, which reads the `clientEnv` Proxy. When `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` are missing on a deploy, the Proxy throws, the error escapes to `global-error.tsx`, and the user sees a wall of Zod JSON instead of the page. Hit this on the PR #171 Vercel preview.
- Catches the env failure and falls back to `isAuthenticated=false` so marketing pages keep rendering. Prod is unaffected — envs are already set there.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] Pre-fix: Vercel preview of this branch blanks `/get-started` (reproduced on PR #171 preview)
- [ ] Post-fix: Vercel preview of THIS PR renders the nav as logged-out and the rest of the page works

🤖 Generated with [Claude Code](https://claude.com/claude-code)