### PR TITLE
feat(profile): surface Firebase-migrated fields in snapshot view

### DIFF
--- a/app/api/dashboard/profile/snapshot/route.ts
+++ b/app/api/dashboard/profile/snapshot/route.ts
@@ -2,7 +2,9 @@
  * Founder Profile Snapshot API
  *
  * GET /api/dashboard/profile/snapshot
- * Returns the full enriched profile for the authenticated user.
+ * Returns the full enriched profile for the authenticated user, including
+ * the Firebase-parity fields backfilled on 2026-04-24 so migrated users
+ * see every value they entered during the Vite/Firebase onboarding.
  */
 
 import { NextResponse } from "next/server";
@@ -10,13 +12,27 @@ import { requireAuth } from "@/lib/auth";
 import { createServiceClient } from "@/lib/supabase/server";
 
 interface ProfileSnapshot {
-  startupName: string | null;
+  founderName: string | null;
+  companyName: string | null;
+  productPositioning: string | null;
   stage: string | null;
-  challenges: string[];
+  stageCategory: string | null;
   industry: string | null;
+  targetMarket: string | null;
+  location: string | null;
+  phone: string | null;
+  challenges: string[];
+  weakSpot: string | null;
+  weakSpotCategory: string | null;
+  ideaStatus: string | null;
+  passions: string | null;
+  coFounder: string | null;
+  hasPartners: boolean | null;
   revenueRange: string | null;
   teamSize: number | null;
   fundingHistory: string | null;
+  realityLensComplete: boolean | null;
+  realityLensScore: number | null;
   enrichedAt: string | null;
   enrichmentSource: string | null;
   createdAt: string | null;
@@ -30,7 +46,10 @@ export async function GET() {
     const { data: profile, error } = await supabase
       .from("profiles")
       .select(
-        "name, stage, challenges, industry, revenue_range, team_size, funding_history, enriched_at, enrichment_source, created_at"
+        "name, company_name, product_positioning, stage, stage_category, industry, target_market, " +
+          "location, phone, challenges, weak_spot, weak_spot_category, idea_status, passions, " +
+          "co_founder, has_partners, revenue_range, team_size, funding_history, " +
+          "reality_lens_complete, reality_lens_score, enriched_at, enrichment_source, created_at",
       )
       .eq("id", userId)
       .single();
@@ -38,21 +57,44 @@ export async function GET() {
     if (error || !profile) {
       return NextResponse.json(
         { success: false, error: "Profile not found" },
-        { status: 404 }
+        { status: 404 },
       );
     }
 
     const snapshot: ProfileSnapshot = {
-      startupName: profile.name ?? null,
-      stage: profile.stage ?? null,
-      challenges: Array.isArray(profile.challenges) ? profile.challenges : [],
-      industry: profile.industry ?? null,
-      revenueRange: profile.revenue_range ?? null,
-      teamSize: profile.team_size ?? null,
-      fundingHistory: profile.funding_history ?? null,
-      enrichedAt: profile.enriched_at ?? null,
-      enrichmentSource: profile.enrichment_source ?? null,
-      createdAt: profile.created_at ?? null,
+      founderName: (profile as { name?: string | null }).name ?? null,
+      companyName: (profile as { company_name?: string | null }).company_name ?? null,
+      productPositioning:
+        (profile as { product_positioning?: string | null }).product_positioning ?? null,
+      stage: (profile as { stage?: string | null }).stage ?? null,
+      stageCategory: (profile as { stage_category?: string | null }).stage_category ?? null,
+      industry: (profile as { industry?: string | null }).industry ?? null,
+      targetMarket: (profile as { target_market?: string | null }).target_market ?? null,
+      location: (profile as { location?: string | null }).location ?? null,
+      phone: (profile as { phone?: string | null }).phone ?? null,
+      challenges: Array.isArray(
+        (profile as unknown as { challenges?: unknown }).challenges,
+      )
+        ? ((profile as unknown as { challenges: unknown[] }).challenges as string[])
+        : [],
+      weakSpot: (profile as { weak_spot?: string | null }).weak_spot ?? null,
+      weakSpotCategory:
+        (profile as { weak_spot_category?: string | null }).weak_spot_category ?? null,
+      ideaStatus: (profile as { idea_status?: string | null }).idea_status ?? null,
+      passions: (profile as { passions?: string | null }).passions ?? null,
+      coFounder: (profile as { co_founder?: string | null }).co_founder ?? null,
+      hasPartners: (profile as { has_partners?: boolean | null }).has_partners ?? null,
+      revenueRange: (profile as { revenue_range?: string | null }).revenue_range ?? null,
+      teamSize: (profile as { team_size?: number | null }).team_size ?? null,
+      fundingHistory: (profile as { funding_history?: string | null }).funding_history ?? null,
+      realityLensComplete:
+        (profile as { reality_lens_complete?: boolean | null }).reality_lens_complete ?? null,
+      realityLensScore:
+        (profile as { reality_lens_score?: number | null }).reality_lens_score ?? null,
+      enrichedAt: (profile as { enriched_at?: string | null }).enriched_at ?? null,
+      enrichmentSource:
+        (profile as { enrichment_source?: string | null }).enrichment_source ?? null,
+      createdAt: (profile as { created_at?: string | null }).created_at ?? null,
     };
 
     return NextResponse.json({ success: true, data: snapshot });
@@ -64,7 +106,7 @@ export async function GET() {
     console.error("[Profile Snapshot] Error:", error);
     return NextResponse.json(
       { success: false, error: "Failed to fetch profile snapshot" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/dashboard/profile/snapshot/page.tsx
+++ b/app/dashboard/profile/snapshot/page.tsx
@@ -12,6 +12,12 @@ import {
   Clock,
   Pencil,
   MessageSquare,
+  MapPin,
+  Phone,
+  User,
+  Compass,
+  Heart,
+  Sparkles,
 } from "lucide-react";
 import {
   Card,
@@ -28,13 +34,27 @@ import { Skeleton } from "@/components/ui/skeleton";
 // ============================================================================
 
 interface ProfileSnapshot {
-  startupName: string | null;
+  founderName: string | null;
+  companyName: string | null;
+  productPositioning: string | null;
   stage: string | null;
-  challenges: string[];
+  stageCategory: string | null;
   industry: string | null;
+  targetMarket: string | null;
+  location: string | null;
+  phone: string | null;
+  challenges: string[];
+  weakSpot: string | null;
+  weakSpotCategory: string | null;
+  ideaStatus: string | null;
+  passions: string | null;
+  coFounder: string | null;
+  hasPartners: boolean | null;
   revenueRange: string | null;
   teamSize: number | null;
   fundingHistory: string | null;
+  realityLensComplete: boolean | null;
+  realityLensScore: number | null;
   enrichedAt: string | null;
   enrichmentSource: string | null;
   createdAt: string | null;
@@ -130,7 +150,7 @@ function FieldRow({
   label,
   value,
 }: {
-  label: string;
+  label: string | React.ReactNode;
   value: string | number | null | undefined;
 }) {
   const displayValue =
@@ -264,25 +284,168 @@ export default function ProfileSnapshotPage() {
 
         {/* Cards Grid */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {/* Startup Info */}
+          {/* Company Info */}
           <Card>
             <CardHeader className="pb-3">
               <div className="flex items-center gap-2">
                 <Building2 className="h-5 w-5 text-[#ff6a1a]" />
-                <CardTitle className="text-lg">Startup Info</CardTitle>
+                <CardTitle className="text-lg">Company</CardTitle>
               </div>
-              <CardDescription>Core company details</CardDescription>
+              <CardDescription>What you are building</CardDescription>
             </CardHeader>
             <CardContent className="space-y-1">
-              <FieldRow label="Name" value={profile.startupName} />
-              <FieldRow
-                label="Stage"
-                value={formatLabel(profile.stage, STAGE_LABELS)}
-              />
+              <FieldRow label="Company name" value={profile.companyName} />
+              <FieldRow label="Positioning" value={profile.productPositioning} />
               <FieldRow
                 label="Industry"
                 value={formatLabel(profile.industry, INDUSTRY_LABELS)}
               />
+              <FieldRow label="Target market" value={profile.targetMarket} />
+              <FieldRow label="Idea status" value={profile.ideaStatus} />
+            </CardContent>
+          </Card>
+
+          {/* Stage */}
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-2">
+                <Compass className="h-5 w-5 text-[#ff6a1a]" />
+                <CardTitle className="text-lg">Stage</CardTitle>
+              </div>
+              <CardDescription>Where the venture is today</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-1">
+              <FieldRow
+                label="Stage"
+                value={
+                  profile.stageCategory ||
+                  formatLabel(profile.stage, STAGE_LABELS)
+                }
+              />
+              {profile.stage && profile.stageCategory ? (
+                <FieldRow label="In your words" value={profile.stage} />
+              ) : null}
+              <FieldRow
+                label="Reality Lens"
+                value={
+                  profile.realityLensComplete && profile.realityLensScore !== null
+                    ? `Complete (score ${profile.realityLensScore})`
+                    : profile.realityLensComplete
+                      ? "Complete"
+                      : null
+                }
+              />
+            </CardContent>
+          </Card>
+
+          {/* Founder */}
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-2">
+                <User className="h-5 w-5 text-[#ff6a1a]" />
+                <CardTitle className="text-lg">Founder</CardTitle>
+              </div>
+              <CardDescription>How we reach you</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-1">
+              <FieldRow label="Name" value={profile.founderName} />
+              <FieldRow
+                label={
+                  <span className="inline-flex items-center gap-1">
+                    <MapPin className="h-3.5 w-3.5" /> Location
+                  </span>
+                }
+                value={profile.location}
+              />
+              <FieldRow
+                label={
+                  <span className="inline-flex items-center gap-1">
+                    <Phone className="h-3.5 w-3.5" /> Phone
+                  </span>
+                }
+                value={profile.phone}
+              />
+              <FieldRow
+                label={
+                  <span className="inline-flex items-center gap-1">
+                    <Heart className="h-3.5 w-3.5" /> Passions
+                  </span>
+                }
+                value={profile.passions}
+              />
+            </CardContent>
+          </Card>
+
+          {/* Team & Co-founder */}
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-2">
+                <Users className="h-5 w-5 text-[#ff6a1a]" />
+                <CardTitle className="text-lg">Team</CardTitle>
+              </div>
+              <CardDescription>Who is building with you</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-1">
+              <FieldRow
+                label="Co-founders"
+                value={
+                  profile.hasPartners === true
+                    ? profile.coFounder || "Yes"
+                    : profile.hasPartners === false
+                      ? "Solo founder"
+                      : profile.coFounder
+                }
+              />
+              <FieldRow
+                label="Team size"
+                value={
+                  profile.teamSize !== null
+                    ? `${profile.teamSize} ${profile.teamSize === 1 ? "person" : "people"}`
+                    : null
+                }
+              />
+            </CardContent>
+          </Card>
+
+          {/* Focus / weak spot */}
+          <Card>
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-2">
+                <Target className="h-5 w-5 text-[#ff6a1a]" />
+                <CardTitle className="text-lg">What to sharpen</CardTitle>
+              </div>
+              <CardDescription>Biggest gap you called out</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-1">
+              <FieldRow
+                label="Category"
+                value={profile.weakSpotCategory}
+              />
+              <FieldRow label="In your words" value={profile.weakSpot} />
+              {profile.challenges.length > 0 ? (
+                <div className="pt-3">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                    Focus areas
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    {profile.challenges.map((c, i) => {
+                      const label =
+                        typeof c === "string"
+                          ? CHALLENGE_LABELS[c] || c
+                          : ((c as { description?: string })?.description ?? "");
+                      if (!label) return null;
+                      return (
+                        <span
+                          key={i}
+                          className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-[#ff6a1a]/10 text-[#ff6a1a]"
+                        >
+                          {label}
+                        </span>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : null}
             </CardContent>
           </Card>
 
@@ -304,54 +467,6 @@ export default function ProfileSnapshotPage() {
                 label="Funding"
                 value={formatLabel(profile.fundingHistory, FUNDING_LABELS)}
               />
-            </CardContent>
-          </Card>
-
-          {/* Team */}
-          <Card>
-            <CardHeader className="pb-3">
-              <div className="flex items-center gap-2">
-                <Users className="h-5 w-5 text-[#ff6a1a]" />
-                <CardTitle className="text-lg">Team</CardTitle>
-              </div>
-              <CardDescription>Team composition</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-1">
-              <FieldRow
-                label="Team Size"
-                value={
-                  profile.teamSize !== null
-                    ? `${profile.teamSize} ${profile.teamSize === 1 ? "person" : "people"}`
-                    : null
-                }
-              />
-            </CardContent>
-          </Card>
-
-          {/* Challenges */}
-          <Card>
-            <CardHeader className="pb-3">
-              <div className="flex items-center gap-2">
-                <Target className="h-5 w-5 text-[#ff6a1a]" />
-                <CardTitle className="text-lg">Challenges</CardTitle>
-              </div>
-              <CardDescription>Focus areas</CardDescription>
-            </CardHeader>
-            <CardContent>
-              {profile.challenges.length > 0 ? (
-                <div className="flex flex-wrap gap-2">
-                  {profile.challenges.map((c) => (
-                    <span
-                      key={c}
-                      className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-[#ff6a1a]/10 text-[#ff6a1a]"
-                    >
-                      {CHALLENGE_LABELS[c] || c}
-                    </span>
-                  ))}
-                </div>
-              ) : (
-                <MutedText>Not yet captured</MutedText>
-              )}
             </CardContent>
           </Card>
         </div>


### PR DESCRIPTION
## Summary
After #175 added 9 first-class columns and backfilled them from `enrichment_data.firebase_raw`, the profile snapshot page still only read the original columns. Migrated users opened their profile and saw most fields as "Not yet captured" even though their Firebase data was preserved on the server. This closes that gap.

## API — `app/api/dashboard/profile/snapshot/route.ts`
Extends `ProfileSnapshot` to include: `companyName`, `productPositioning`, `stageCategory`, `targetMarket`, `location`, `phone`, `weakSpot`, `weakSpotCategory`, `ideaStatus`, `passions`, `coFounder`, `hasPartners`, `realityLensComplete`, `realityLensScore`, `founderName`. Query selects the new columns.

## Page — `app/dashboard/profile/snapshot/page.tsx`
6-card grid (was 4): **Company**, **Stage**, **Founder**, **Team**, **What to sharpen**, **Financials**.
- Company card: name + positioning + industry + target market + idea status
- Founder card: name, location, phone, passions
- Stage card: stage_category + free-text stage + reality lens score
- Team card: has_partners-aware co-founder rendering, team size
- What to sharpen: weak_spot_category + weak_spot + existing challenge chips

## Test plan
- [ ] Sign in as Bill Hood (`billhoodtaos@gmail.com`). Navigate to `/dashboard/profile/snapshot`. Expect: AI Replicas, Taos NM, phone, Ideation, Problem Validation, 65 reality-lens score.
- [ ] Sign in as an Alex Barmen migrated user. Expect: AI Barmen, Santa Clara CA, Seed, Unit Economics.
- [ ] Sign in as a native (non-Firebase) user. Fields not populated show as "Not yet captured" — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)