### PR TITLE
feat(onboarding): restore 4-step wizard + business-fundamentals step

### DIFF
--- a/app/get-started/page.tsx
+++ b/app/get-started/page.tsx
@@ -31,7 +31,7 @@ import { trackEvent } from "@/lib/analytics";
 import { ANALYTICS_EVENTS } from "@/lib/analytics/events";
 
 // Types
-type Step = 1 | 2 | 3 | "wink";
+type Step = 1 | 2 | 3 | 4 | "wink";
 type Stage = "idea" | "pre-seed" | "seed" | "series-a";
 type Challenge =
   | "product-market-fit"
@@ -81,9 +81,7 @@ function loadWizardState(): { step: Step; stage: Stage | null; challenge: Challe
     const stored = localStorage.getItem(WIZARD_STORAGE_KEY);
     if (stored) {
       const parsed = JSON.parse(stored);
-      // Clamp legacy 4-step state back to valid 3-step range
-      let step = parsed.step ?? 1;
-      if (step === 4) step = 3;
+      const step = parsed.step ?? 1;
       return {
         step,
         stage: parsed.stage ?? null,
@@ -239,8 +237,13 @@ const OnboardingPage = () => {
 
   const handleChallengeSelect = (challenge: Challenge) => {
     setSelectedChallenge(challenge);
-    // Auto-advance after short delay
+    // Auto-advance to step 3 (business fundamentals)
     setTimeout(() => setCurrentStep(3), 300);
+  };
+
+  const handleFundamentalsContinue = () => {
+    setError(null);
+    setCurrentStep(4);
   };
 
   const updateFundamental = <K extends keyof BusinessFundamentals>(key: K, value: BusinessFundamentals[K]) => {
@@ -251,6 +254,7 @@ const OnboardingPage = () => {
     setError(null);
     if (currentStep === 2) setCurrentStep(1);
     if (currentStep === 3) setCurrentStep(2);
+    if (currentStep === 4) setCurrentStep(3);
   };
 
   const handleSubmit = async () => {
@@ -319,7 +323,7 @@ const OnboardingPage = () => {
   };
 
   // Progress dots
-  const stepNumber = currentStep === "wink" ? 3 : currentStep;
+  const stepNumber = currentStep === "wink" ? 4 : currentStep;
 
   return (
     <div className="relative min-h-screen bg-white dark:bg-gray-950 overflow-hidden">
@@ -336,7 +340,7 @@ const OnboardingPage = () => {
           {/* Progress dots */}
           {currentStep !== "wink" && (
             <div className="fixed top-20 lg:top-24 right-4 sm:right-6 lg:right-8 z-40 flex items-center gap-2">
-              {[1, 2, 3].map((step) => (
+              {[1, 2, 3, 4].map((step) => (
                 <div
                   key={step}
                   className={`w-3 h-3 rounded-full transition-all duration-300 ${
@@ -369,7 +373,7 @@ const OnboardingPage = () => {
                       className="inline-flex items-center gap-2 px-3 py-1.5 bg-[#ff6a1a]/10 text-[#ff6a1a] rounded-full text-sm font-medium"
                     >
                       <Sparkles className="w-4 h-4" />
-                      3 clicks to get started
+                      4 quick steps to get started
                     </motion.div>
                     <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white">
                       What stage are you at?
@@ -483,10 +487,86 @@ const OnboardingPage = () => {
                 </motion.div>
               )}
 
-              {/* Step 3: Enter Email - Create Account */}
+              {/* Step 3: Business fundamentals */}
               {currentStep === 3 && (
                 <motion.div
-                  key="step3"
+                  key="step3-fundamentals"
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -20 }}
+                  transition={{ duration: 0.3 }}
+                  className="space-y-8"
+                >
+                  <div className="text-center space-y-3">
+                    <h1 className="text-3xl md:text-4xl font-bold text-gray-900 dark:text-white">
+                      Tell us about your <span className="text-[#ff6a1a]">business</span>
+                    </h1>
+                    <p className="text-gray-600 dark:text-gray-400">
+                      A few quick details so FRED can tailor the coaching
+                    </p>
+                  </div>
+
+                  <div className="max-w-md mx-auto">
+                    <div className="bg-white dark:bg-gray-900 rounded-2xl p-6 border border-gray-200 dark:border-gray-800 shadow-lg">
+                      {/* Summary chips */}
+                      <div className="flex flex-wrap gap-2 mb-6">
+                        {selectedStage && (
+                          <span className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-[#ff6a1a]/10 text-[#ff6a1a] rounded-full text-sm font-medium">
+                            {stages.find((s) => s.id === selectedStage)?.title}
+                          </span>
+                        )}
+                        {selectedChallenge && (
+                          <span className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 rounded-full text-sm font-medium">
+                            {challenges.find((c) => c.id === selectedChallenge)?.title}
+                          </span>
+                        )}
+                      </div>
+
+                      <div className="space-y-4">
+                        <div>
+                          <label htmlFor="onboard-business-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            What are you building?
+                          </label>
+                          <input
+                            id="onboard-business-name"
+                            type="text"
+                            placeholder="e.g. Acme Labs"
+                            value={fundamentals.businessName}
+                            onChange={(e) => updateFundamental("businessName", e.target.value)}
+                            autoFocus
+                            className="w-full px-4 py-3.5 rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-white placeholder:text-gray-400 focus:border-[#ff6a1a] focus:ring-2 focus:ring-[#ff6a1a]/20 focus:bg-white dark:focus:bg-gray-900 outline-none transition-all text-lg"
+                          />
+                        </div>
+
+                        <Button
+                          size="lg"
+                          onClick={handleFundamentalsContinue}
+                          className="w-full bg-[#ff6a1a] hover:bg-[#ea580c] text-white text-lg py-6 shadow-lg shadow-[#ff6a1a]/25 hover:shadow-[#ff6a1a]/40 transition-all"
+                        >
+                          Continue
+                          <ArrowRight className="ml-2 h-5 w-5" />
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="flex justify-start">
+                    <Button
+                      variant="ghost"
+                      onClick={handleBack}
+                      className="gap-2 text-gray-600 dark:text-gray-400"
+                    >
+                      <ArrowLeft className="w-4 h-4" />
+                      Back
+                    </Button>
+                  </div>
+                </motion.div>
+              )}
+
+              {/* Step 4: Enter Email - Create Account */}
+              {currentStep === 4 && (
+                <motion.div
+                  key="step4"
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -20 }}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,18 +32,12 @@ export default defineConfig({
     //     intent: any prompt change requires manual review + new SHA.
     //     Fix: restore prompt bytes to match SHA 08466134..., or get an
     //     out-of-band test update to reflect the newly-approved prompt.
-    //   * tests/pages/get-started.test.tsx
-    //     Tests assume a 4-step onboarding wizard with a business-name
-    //     input on step 3 ("e.g. Acme Labs" placeholder). The current
-    //     implementation is 3 steps with no business-name input on the
-    //     account screen. Restructure the page to match the test spec.
     //   * tests/pages/readiness.test.tsx
     //     FeatureLock expectation for Free-tier users no longer triggers
     //     the gated rendering path. Restore the gating behavior.
     exclude: [
       '**/node_modules/**', '.next', 'dist', '.claude', 'funnel/**',
       'lib/ai/__tests__/voice-regression.test.ts',
-      'tests/pages/get-started.test.tsx',
       'tests/pages/readiness.test.tsx',
     ],
     pool: 'threads',


### PR DESCRIPTION
## Summary
Onboarding wizard silently collapsed from 4 steps to 3, dropping the business-fundamentals step that collects `company_name` before account creation. The test file (`tests/pages/get-started.test.tsx`) encoded the original 4-step spec; it was excluded from CI in #176 as pre-existing drift. This PR restores the step and re-enables the test.

## New flow
1. **Stage selection** — header now reads "4 quick steps to get started" (was "3 clicks")
2. **Challenge selection** — unchanged
3. **Business fundamentals** — NEW. Summary chips for stage + challenge, then a "What are you building?" text input with placeholder `e.g. Acme Labs` and a Continue button. Back returns to step 2.
4. **Email / password** — was step 3, identical UI. Still posts `fundamentals.businessName` as `company_name` on submit.

## Extras
- Wizard state persistence accepts step 4 (no longer clamps 4 → 3)
- Progress dots render 4 instead of 3
- `vitest.config.ts` unexcludes `tests/pages/get-started.test.tsx`

## Verification
```
npx vitest run tests/pages/get-started.test.tsx
13 passed (13)
```
Full repo suite: 63 files / 1145 tests passing (was 62/1132 before this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)