### PR TITLE
docs(test): explain why voice-regression SHA snapshot is structurally stuck

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,14 +24,20 @@ export default defineConfig({
     // funnel/node_modules/zod/**/*.test.ts — the Vite sub-project under
     // funnel/ ships zod's own test files that would otherwise run here.
     //
-    // Pre-existing test<->implementation drift. Each entry below needs the
-    // IMPLEMENTATION fixed to match the test, then the entry removed.
-    //   * lib/ai/__tests__/voice-regression.test.ts
-    //     CORE_PROMPT_SHA256 snapshot went stale after prompt edits that
-    //     did not bump the hash in the locked test. The "frozen" contract
-    //     intent: any prompt change requires manual review + new SHA.
-    //     Fix: restore prompt bytes to match SHA 08466134..., or get an
-    //     out-of-band test update to reflect the newly-approved prompt.
+    // lib/ai/__tests__/voice-regression.test.ts — "core prompt SHA-256
+    // matches snapshot" expects SHA 08466134227e7b9743b8292636310db48d36-
+    // bf53365acb480511096cf8da58e5. That value was put into the test in
+    // commit 77b6e0dc (2026-04-22 "fix(tests): unblock CI") but it never
+    // matched the actual prompt bytes — at THAT commit, FRED_CORE_PROMPT.
+    // content already hashed to 663802b22fc002076bfa1bf77c8fe160ad23fd1c-
+    // 23d492f0a0293bd55cee87a3 (and still does at HEAD — the prompt has
+    // not been touched since). The author likely hashed a local WIP edit
+    // that was reverted before committing. The test is frozen under a
+    // PreToolUse hook that blocks any edit to test files, so fixing the
+    // snapshot must happen out of band (manual human edit to
+    // CORE_PROMPT_SHA256 in the test). Re-enable this entry once that
+    // constant is either (a) updated to the live prompt SHA, or (b)
+    // moved into a source-of-truth module the implementation can write.
     exclude: [
       '**/node_modules/**', '.next', 'dist', '.claude', 'funnel/**',
       'lib/ai/__tests__/voice-regression.test.ts',


### PR DESCRIPTION
## Summary
Updates the `vitest.config.ts` exclusion comment for `lib/ai/__tests__/voice-regression.test.ts` with the root cause so the next person who stumbles on the red test doesn't spend time trying to fix it from the code side.

## Finding
`CORE_PROMPT_SHA256` expects `08466134...` but `FRED_CORE_PROMPT.content` has hashed to `663802b2...` since commit 77b6e0dc (2026-04-22). The SHA was wrong in the commit that introduced it — the author likely computed the hash from a local WIP edit that was reverted before committing.

The test file is frozen under the `protect-tests.sh` PreToolUse hook. Fixing it requires a one-line human edit to the `CORE_PROMPT_SHA256` constant in the test. Until then, exclusion stays.

## Change
Comment-only. No code behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)