### PR TITLE
fix(voice): default to the working Fred Sahara voice clone

### DIFF
--- a/workers/voice-agent/agent.ts
+++ b/workers/voice-agent/agent.ts
@@ -254,7 +254,13 @@ export default defineAgent({
     const stt = new openai.STT({ model: 'whisper-1' });
     const llm = new openai.LLM({ model: 'gpt-4o', temperature: 0.7 });
     const tts = new elevenlabs.TTS({
-      voiceId: process.env.ELEVENLABS_VOICE_ID || 'uxq5gLBpu73uF1Aqzb2t', // Fred Zaharix voice (ElevenLabs)
+      // Fred Sahara (instant-clone ElevenLabs voice). The "Fred Cary 2026"
+      // professional clone (uxq5gLBpu73uF1Aqzb2t) has its fine-tuning in a
+      // failed state on every model, so any TTS call using it returns
+      // HTTP 400 voice_not_fine_tuned and LiveKit falls back to a default
+      // non-Fred voice. Keep this fallback on the working instant clone
+      // until the professional clone is re-trained.
+      voiceId: process.env.ELEVENLABS_VOICE_ID || 'fpxks3eObfRI1jkeCD2k',
     });
 
     const session = new AgentSession({

--- a/workers/voice-agent/dist/workers/voice-agent/agent.js
+++ b/workers/voice-agent/dist/workers/voice-agent/agent.js
@@ -63,7 +63,7 @@ export default defineAgent({
         }
         const stt = new openai.STT({ model: 'whisper-1' });
         const llm = new openai.LLM({ model: 'gpt-4o', temperature: 0.7 });
-        const tts = new elevenlabs.TTS({ voiceId: process.env.ELEVENLABS_VOICE_ID || 'uxq5gLBpu73uF1Aqzb2t' });
+        const tts = new elevenlabs.TTS({ voiceId: process.env.ELEVENLABS_VOICE_ID || 'fpxks3eObfRI1jkeCD2k' });
         const session = new AgentSession({
             vad: ctx.proc.userData.vad,
             stt,


### PR DESCRIPTION
## Summary
- Root-cause for the "voice isn't Fred's voice" bug: the ElevenLabs **Fred Cary 2026** professional clone (`uxq5gLBpu73uF1Aqzb2t`) has fine-tuning failed on **every model** in the account, so TTS calls return `HTTP 400 voice_not_fine_tuned` and LiveKit falls back to a default non-Fred voice.
- The **Fred Sahara** instant clone (`fpxks3eObfRI1jkeCD2k`) synthesizes correctly (verified by calling `/v1/text-to-speech` — returned a 71 KB MP3).
- Swap the code fallback back to the working ID. Keeps #26's env-driven pattern.

## Evidence
```
$ curl .../v1/voices | jq '.voices[] | select(.name | test("Fred"))'
id=uxq5gLBpu73uF1Aqzb2t  name='Fred Cary 2026'  category=professional
  fine_tuning.state = { turbo_v2_5: failed, flash_v2: failed,
    multilingual_v2: failed, v2_5_flash: failed, v2_flash: failed,
    turbo_v2: failed, flash_v2_5: failed, multilingual_sts_v2: not_started }

id=fpxks3eObfRI1jkeCD2k  name='Fred Sahara'  category=cloned
  TTS HTTP 200, 71KB MP3 produced
```

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] TTS API sample generated against the new fallback ID
- [ ] Update `ELEVENLABS_VOICE_ID` on Railway (voice worker) → `fpxks3eObfRI1jkeCD2k`
- [ ] Update `ELEVENLABS_VOICE_ID` on Vercel prod → `fpxks3eObfRI1jkeCD2k`
- [ ] Restart the LiveKit worker container
- [ ] Hit /chat → "Talk to Fred" → confirm Fred's voice on the live call

## Follow-up
- Fred to re-cut samples in ElevenLabs so the "Fred Cary 2026" professional clone can retrain successfully; swap back once it's `state=ready`.

## Note on tests
`tests/voice/voice-e2e-qa.test.ts` still hard-codes the old ID, but the assertion is tautological (`voiceId === voiceId`) so it keeps passing. A protect-tests hook blocks editing it here; recommend cleaning up the test description in a separate PR with the hook temporarily lifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)