### PR TITLE
AI-8874: Restore you.joinsahara.com CTAs + u.joinsahara.com middleware redirect

### DIFF
--- a/app/demo/boardy/page.tsx
+++ b/app/demo/boardy/page.tsx
@@ -351,7 +351,7 @@ export default function BoardyDemo() {
               </p>
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <Button asChild className="bg-gradient-to-r from-orange-500 to-orange-600 hover:opacity-90">
-                  <Link href="/get-started">
+                  <Link href="https://you.joinsahara.com">
                     Start Free Trial
                     <RocketIcon className="ml-2 h-4 w-4" />
                   </Link>

--- a/app/demo/pitch-deck/page.tsx
+++ b/app/demo/pitch-deck/page.tsx
@@ -267,7 +267,7 @@ export default function PitchDeckDemo() {
                 </p>
                 <div className="flex flex-col sm:flex-row gap-4 justify-center">
                   <Button asChild className="bg-gradient-to-r from-orange-500 to-red-500 hover:opacity-90">
-                    <Link href="/get-started">
+                    <Link href="https://you.joinsahara.com">
                       Start Free Trial
                       <RocketIcon className="ml-2 h-4 w-4" />
                     </Link>

--- a/app/demo/reality-lens/page.tsx
+++ b/app/demo/reality-lens/page.tsx
@@ -224,7 +224,7 @@ export default function RealityLensDemo() {
               </div>
 
               <Button asChild size="lg" className="w-full bg-[#ff6a1a] hover:bg-[#ea580c] text-white shadow-lg shadow-[#ff6a1a]/25 mt-8">
-                <Link href="/get-started">
+                <Link href="https://you.joinsahara.com">
                   Get Started Free <ArrowRight className="ml-2 w-4 h-4" />
 
                 </Link>

--- a/app/demo/virtual-team/page.tsx
+++ b/app/demo/virtual-team/page.tsx
@@ -733,7 +733,7 @@ export default function VirtualTeamDemo() {
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Button asChild size="lg" className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white shadow-lg shadow-[#ff6a1a]/25">
-                <Link href="/get-started">
+                <Link href="https://you.joinsahara.com">
                   Activate My Team <ArrowRight className="ml-2 w-4 h-4" />
                 </Link>
               </Button>

--- a/app/features/page.tsx
+++ b/app/features/page.tsx
@@ -144,7 +144,7 @@ export default function FeaturesPage() {
               <Link href="/pricing">View Pricing</Link>
             </Button>
             <Button asChild variant="outline" size="lg" className="hover:border-[#ff6a1a]/30 hover:text-[#ff6a1a]">
-              <Link href="/get-started">Get Started Free</Link>
+              <Link href="https://you.joinsahara.com">Get Started Free</Link>
             </Button>
           </div>
         </motion.div>
@@ -228,7 +228,7 @@ export default function FeaturesPage() {
             Start with our free tier. No credit card required.
           </p>
           <Button asChild size="lg" className="bg-[#ff6a1a] hover:bg-[#ea580c] text-white shadow-lg shadow-[#ff6a1a]/25">
-            <Link href="/get-started">Get Started Free</Link>
+            <Link href="https://you.joinsahara.com">Get Started Free</Link>
           </Button>
         </motion.div>
       </section>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -301,7 +301,7 @@ function LoginContent() {
             <p className="text-gray-600 dark:text-gray-400">
               Don&apos;t have an account?{" "}
               <Link
-                href="/get-started"
+                href="https://you.joinsahara.com"
                 // orange-800 to clear AA against the soft cream wash. orange-700
                 // (#c2410c) measured 4.36:1, just under the 4.5:1 minimum.
                 className="font-medium text-[#9a3412] hover:text-[#7c2d12]"

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -291,7 +291,7 @@ export default function PricingPage() {
                         variant={plan.popular ? "default" : "outline"}
                         size="lg"
                       >
-                        <Link href="https://you.joinsahara.com">{plan.cta}</Link>
+                        <Link href="/get-started">{plan.cta}</Link>
                       </Button>
                     </div>
                   </div>

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -291,7 +291,7 @@ export default function PricingPage() {
                         variant={plan.popular ? "default" : "outline"}
                         size="lg"
                       >
-                        <Link href="/get-started">{plan.cta}</Link>
+                        <Link href="https://you.joinsahara.com">{plan.cta}</Link>
                       </Button>
                     </div>
                   </div>

--- a/app/tools/investor-readiness/page.tsx
+++ b/app/tools/investor-readiness/page.tsx
@@ -213,7 +213,7 @@ export default function InvestorReadinessPage() {
 
       <div className="relative z-10 py-20 px-4">
         <div className="container max-w-4xl mx-auto">
-          <Link href="/get-started">
+          <Link href="https://you.joinsahara.com">
             <Button variant="ghost" className="mb-6 text-gray-600 dark:text-gray-400 hover:text-[#ff6a1a]">
               <ArrowLeft className="w-4 h-4 mr-2" />
               Back

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -60,7 +60,7 @@ const Footer = () => {
               asChild
               className="w-fit bg-[#ff6a1a] hover:bg-[#ea580c] text-white shadow-lg shadow-[#ff6a1a]/25 hover:shadow-[#ff6a1a]/40 transition-all"
             >
-              <Link href="/get-started">
+              <Link href="https://you.joinsahara.com">
                 Get Started Free
                 <RocketIcon className="ml-2 h-4 w-4" />
               </Link>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -141,7 +141,7 @@ export default function Hero() {
             <HeroButtonExpandable
               mainText="Get Started"
               expandedText="Let's Build"
-              href="/get-started"
+              href="https://you.joinsahara.com"
             />
 
             <motion.div
@@ -154,7 +154,7 @@ export default function Hero() {
                 size="lg"
                 className="text-lg px-8 h-14 border-2 border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-[#702425] hover:text-[#702425] bg-transparent transition-all duration-300"
               >
-                <Link href="/get-started" className="flex items-center gap-2">
+                <Link href="https://you.joinsahara.com" className="flex items-center gap-2">
                   Join Now
                   <motion.span
                     animate={{ x: [0, 5, 0] }}
@@ -314,7 +314,7 @@ export default function Hero() {
                         size="lg"
                         className="text-lg px-8 h-14 bg-[#ff6a1a] hover:bg-[#ea580c] text-white border-0 shadow-lg shadow-[#ff6a1a]/25 hover:shadow-[#ff6a1a]/40 transition-all duration-300"
                       >
-                        <Link href="/get-started" className="flex items-center gap-2">
+                        <Link href="https://you.joinsahara.com" className="flex items-center gap-2">
                           Get Started
                           <ArrowRight className="h-5 w-5" />
                         </Link>
@@ -472,7 +472,7 @@ export default function Hero() {
               size="lg"
               className="text-xl px-12 h-16 bg-[#ff6a1a] hover:bg-[#ea580c] text-white border-0 shadow-2xl shadow-[#ff6a1a]/30 hover:shadow-[#ff6a1a]/50 transition-all duration-300"
             >
-              <Link href="/get-started" className="flex items-center gap-3">
+              <Link href="https://you.joinsahara.com" className="flex items-center gap-3">
                 Get Started
                 <ArrowRight className="h-6 w-6" />
               </Link>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -208,13 +208,13 @@ function NavBar() {
                 ) : (
                   <>
                     <Button asChild size="lg" variant="outline" className="w-full touch-target border-gray-300 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-[#ff6a1a] hover:text-[#ff6a1a]">
-                      <Link href="/login" onClick={() => setIsMenuOpen(false)}>
+                      <Link href="https://you.joinsahara.com" onClick={() => setIsMenuOpen(false)}>
                         Login
                       </Link>
                     </Button>
 
                     <Button asChild size="lg" className="w-full touch-target bg-[#ff6a1a] hover:bg-[#ea580c] text-white border-0 shadow-lg shadow-[#ff6a1a]/25">
-                      <Link href="/get-started" onClick={() => setIsMenuOpen(false)}>
+                      <Link href="https://you.joinsahara.com" onClick={() => setIsMenuOpen(false)}>
                         Get Started Free
                         <RocketIcon className="ml-2 h-4 w-4" />
                       </Link>
@@ -319,7 +319,7 @@ function NavBar() {
                   className="flex border-2 border-[#ff6a1a] text-[#ff6a1a] dark:text-[#ff6a1a] bg-white/90 dark:bg-gray-950/90 hover:bg-[#ff6a1a] hover:text-white dark:hover:text-white font-semibold shadow-md transition-all duration-300 touch-target"
                   size="sm"
                 >
-                  <Link href="/login" aria-label="Log in to your account">
+                  <Link href="https://you.joinsahara.com" aria-label="Log in to your account">
                     Log in
                   </Link>
                 </Button>
@@ -328,7 +328,7 @@ function NavBar() {
                   className="hidden sm:flex bg-[#ff6a1a] hover:bg-[#ea580c] text-white border-0 shadow-lg shadow-[#ff6a1a]/25 hover:shadow-[#ff6a1a]/40 transition-all duration-300 touch-target"
                   size="sm"
                 >
-                  <Link href="/get-started">
+                  <Link href="https://you.joinsahara.com">
                     Get Started Free
                     <RocketIcon className="ml-2 h-4 w-4" />
                   </Link>

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -16,8 +16,8 @@ export default function Pricing() {
 
   const handleSubscribe = async (priceId: string | null | undefined, planName: string) => {
     if (!priceId) {
-      // Free plan - redirect to the get-started wizard (formerly you.joinsahara.com)
-      window.location.assign("/get-started");
+      // Free plan - redirect to you.joinsahara.com
+      window.location.assign("https://you.joinsahara.com");
       return;
     }
 

--- a/config/linear.json
+++ b/config/linear.json
@@ -1,0 +1,12 @@
+{
+  "enabled": true,
+  "team": {
+    "id": "9a9d11aa-c8a5-4dc5-855c-c1da260db615",
+    "key": "AI",
+    "name": "Ai Acrobatics"
+  },
+  "project": {
+    "id": "d884374c-0c58-4e7c-a19a-d62c4daf55e2",
+    "name": "Sahara - AI Founder OS"
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,22 +38,30 @@ export async function middleware(request: NextRequest) {
   const origin = request.headers.get("origin");
 
   // ---------------------------------------------------------------------
-  // you.joinsahara.com deprecation (2026-04-22). The legacy Firebase-backed
-  // funnel subdomain (hosted on a separate Vercel project serving the
-  // Vite funnel app) is consolidated onto the permanent platform. Any
-  // request arriving with the legacy host header is 308-redirected to the
-  // equivalent path on www.joinsahara.com, with a ?from=funnel-migration
-  // flag so the landing page can show a one-time "welcome back" banner
-  // (see components/welcome-back-banner.tsx).
+  // you.joinsahara.com / u.joinsahara.com deprecation (2026-04-22). The
+  // legacy Firebase-backed funnel subdomain (hosted on a separate Vercel
+  // project serving the Vite funnel app) is consolidated onto the permanent
+  // platform. Any request arriving with either legacy host header is
+  // 308-redirected to the equivalent path on www.joinsahara.com, with a
+  // ?from=funnel-migration flag so the landing page can show a one-time
+  // "welcome back" banner (see components/welcome-back-banner.tsx).
   //
-  // NOTE: this middleware only fires once you.joinsahara.com is pointed at
+  // u.joinsahara.com is included alongside you.joinsahara.com because both
+  // appear historically in the changelog, the Vite funnel app's og:url, the
+  // QR-code targets in the founder PRD, and external collateral (WhatsApp
+  // shares, decks). Keeping both supported costs nothing and prevents
+  // referrers landing on a dead host if u.joinsahara.com ever gets DNS.
+  //
+  // NOTE: this middleware only fires once the legacy host is pointed at
   // THIS Vercel project. Until the domain is moved (or DNS is flipped)
   // this block is defensive / a no-op.
   // ---------------------------------------------------------------------
   const host = (request.headers.get("host") || "").toLowerCase();
   if (
     host === "you.joinsahara.com" ||
-    host.startsWith("you.joinsahara.com:")
+    host.startsWith("you.joinsahara.com:") ||
+    host === "u.joinsahara.com" ||
+    host.startsWith("u.joinsahara.com:")
   ) {
     const target = new URL(pathname, "https://www.joinsahara.com");
     // Preserve the original query string.


### PR DESCRIPTION
Implements AI-8874.

## Changes

### 1. Landing CTAs → `you.joinsahara.com` (commit 3da6e858)
Re-points public-facing CTA buttons at the legacy funnel host instead of local routes. Auth'd users still hit `/dashboard` via the `showAuthedNav` branches in `navbar.tsx`. Restores the same target set by 7ec37f9a; CTAs had reverted to internal routes during unrelated sweeps.

Files: hero, navbar, footer, pricing component + page, login signup link, demo pages (boardy / pitch-deck / reality-lens / virtual-team), features page, investor-readiness tool back-link.

### 2. Middleware host-redirect for `u.joinsahara.com` (commit 403b8c49)
Reverts the relevant portion of d8e8a20e. `u.joinsahara.com` now 308-redirects to `www.joinsahara.com?from=funnel-migration` with the same path-remap and welcome-back banner as the `you.joinsahara.com` clause. Defensive coverage for og:url metadata, QR-code targets, WhatsApp shares, external decks, and any future DNS flip — no prod behavior change today since `u.joinsahara.com` has no DNS pointing here.

### 3. `config/linear.json` pin (commit 15ddd68e)
Pins the Sahara repo to its correct Linear project so future auto-created issues land in the right place.

## Verification
- `you.joinsahara.com` appears across all 7 surfaces named in the issue (hero, navbar, footer, pricing, demo, features, tools).
- Auth'd nav still routes to `/dashboard` via existing branches.
- Middleware tests already cover the `you.joinsahara.com` path; `u.joinsahara.com` follows the identical code branch.

Linear: AI-8874