### PR TITLE
feat(sms): AI-8892 backup SMS delivery for users without iMessage

### DIFF
--- a/app/api/sms/preferences/route.ts
+++ b/app/api/sms/preferences/route.ts
@@ -18,6 +18,7 @@ import {
   updateSMSPreferences,
   getCheckinHistory,
 } from "@/lib/db/sms";
+import { getVoiceSetupConfirmationTemplate } from "@/lib/sms/templates";
 import { createClient } from "@/lib/supabase/server";
 import { z } from "zod";
 
@@ -139,6 +140,10 @@ export async function POST(request: NextRequest) {
     // User-scoped client for user-initiated request (Phase 11-06)
     const supabase = await createClient();
 
+    // Read existing prefs to detect first-time check-in enable
+    const existingPreferences = await getUserSMSPreferences(supabase, userId);
+    const wasCheckinEnabled = existingPreferences?.checkinEnabled ?? false;
+
     // If a phone number is being set, verify it has been confirmed
     if (updates.phoneNumber) {
       const { data: verification } = await supabase
@@ -168,6 +173,36 @@ export async function POST(request: NextRequest) {
       checkinHour: updates.checkinHour,
       timezone: updates.timezone,
     });
+
+    // Fire-and-forget voice-setup confirmation on first check-in enable
+    const justEnabled = updates.checkinEnabled === true && !wasCheckinEnabled;
+    const phoneForConfirmation = preferences.phoneNumber ?? updates.phoneNumber;
+    if (justEnabled && phoneForConfirmation && preferences.phoneVerified) {
+      (async () => {
+        try {
+          const { sendSMS } = await import("@/lib/sms/client");
+          const { data: profile } = await supabase
+            .from("profiles")
+            .select("name")
+            .eq("id", userId)
+            .single();
+          const founderName =
+            (profile?.name as string | undefined)?.split(" ")[0] || "Founder";
+          await sendSMS(
+            phoneForConfirmation,
+            getVoiceSetupConfirmationTemplate(founderName)
+          );
+          console.info(
+            `[SMS Preferences] Voice setup confirmation sent to user ${userId}`
+          );
+        } catch (smsErr) {
+          console.warn(
+            "[SMS Preferences] Voice setup confirmation SMS failed (non-blocking):",
+            smsErr
+          );
+        }
+      })();
+    }
 
     return NextResponse.json({ preferences });
   } catch (error) {

--- a/app/api/sms/verify/route.ts
+++ b/app/api/sms/verify/route.ts
@@ -19,6 +19,7 @@ import {
   createTierErrorResponse,
 } from "@/lib/api/tier-middleware";
 import { sendSMS } from "@/lib/sms/client";
+import { getWelcomeTemplate } from "@/lib/sms/templates";
 import { createClient } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
@@ -171,6 +172,23 @@ export async function PUT(request: NextRequest) {
         { status: 500 }
       );
     }
+
+    // Fire-and-forget welcome SMS -- confirm backup SMS delivery and introduce FRED
+    (async () => {
+      try {
+        const { data: profile } = await supabase
+          .from("profiles")
+          .select("name")
+          .eq("id", userId)
+          .single();
+        const founderName =
+          (profile?.name as string | undefined)?.split(" ")[0] || "Founder";
+        await sendSMS(phoneNumber, getWelcomeTemplate(founderName));
+        console.info(`[SMS Verify] Welcome SMS sent to user ${userId}`);
+      } catch (smsErr) {
+        console.warn("[SMS Verify] Welcome SMS failed (non-blocking):", smsErr);
+      }
+    })();
 
     return NextResponse.json({
       success: true,

--- a/lib/sms/templates.ts
+++ b/lib/sms/templates.ts
@@ -84,3 +84,15 @@ export function getWelcomeTemplate(founderName: string): string {
 export function getStopConfirmation(): string {
   return "Got it -- you're unsubscribed from check-ins. Text START anytime to jump back in. --Fred";
 }
+
+/**
+ * Confirmation message sent when a user first enables SMS check-ins,
+ * confirming backup SMS delivery and introducing the FRED voice feature.
+ *
+ * @param founderName - First name of the founder
+ * @returns SMS message body (max 160 chars)
+ */
+export function getVoiceSetupConfirmationTemplate(founderName: string): string {
+  const full = `You're all set, ${founderName}! Fred will text weekly check-ins. You can also call Fred anytime via the Sahara app. Reply STOP to opt out.`;
+  return full.length <= MAX_SMS_LENGTH ? full : full.slice(0, MAX_SMS_LENGTH);
+}


### PR DESCRIPTION
## Summary
- Adds `getVoiceSetupConfirmationTemplate()` to `lib/sms/templates.ts` — confirms weekly check-ins and introduces FRED voice via the Sahara app
- Sends a welcome SMS (fire-and-forget) after phone verification succeeds (`PUT /api/sms/verify`) — covers founders who don't use iMessage at onboarding
- Sends a voice-setup confirmation SMS (fire-and-forget) when check-ins are first enabled (`POST /api/sms/preferences`) — confirms both the SMS backup channel and 11 Labs voice availability

All SMS sends are fire-and-forget (non-blocking) — failures are logged as warnings and never crash the API response.

## Test plan
- [ ] Verify phone via `PUT /api/sms/verify` → welcome SMS delivered to test number
- [ ] Enable check-ins for first time via `POST /api/sms/preferences` → voice-setup confirmation SMS delivered
- [ ] Re-enabling check-ins (already was enabled) → no duplicate confirmation sent
- [ ] Twilio credentials absent → SMS silently skipped, API still returns 200
- [ ] TypeScript: `npx tsc --noEmit` passes with zero errors

Linear: AI-8892

🤖 Generated with [Claude Code](https://claude.com/claude-code)