### PR TITLE
AI-8890: Fix chatbot infinite loop + improve UI contrast

### DIFF
--- a/app/api/fred/chat/route.ts
+++ b/app/api/fred/chat/route.ts
@@ -84,7 +84,45 @@ const chatRequestSchema = z.object({
   storeInMemory: z.boolean().default(true),
   /** Current page path so FRED can provide navigation-aware guidance */
   pageContext: z.string().max(200).optional(),
+  /** Number of user messages sent in this session (for loop-breaking) */
+  exchangeCount: z.number().int().min(0).max(500).optional(),
 });
+
+// ============================================================================
+// Loop-Breaker: cap repetitive exchanges
+// ============================================================================
+
+/**
+ * Maximum user exchanges before FRED wraps up with actionable advice.
+ * After this many user messages in a session, FRED stops asking follow-up
+ * questions and provides a concrete summary with next steps.
+ */
+const MAX_EXCHANGES_BEFORE_WRAPUP = 8;
+
+function buildLoopBreakerBlock(exchangeCount: number): string {
+  if (exchangeCount < MAX_EXCHANGES_BEFORE_WRAPUP) return "";
+
+  if (exchangeCount < MAX_EXCHANGES_BEFORE_WRAPUP + 3) {
+    return `## CONVERSATION GUIDANCE — WRAP UP MODE
+This conversation has had ${exchangeCount} exchanges. You MUST now:
+1. Stop asking follow-up or clarifying questions
+2. Synthesize everything discussed so far into 2-3 concrete action items
+3. Give the founder a clear "here's what to do next" with specific steps
+4. If they ask another question, answer it directly and end with action items — do NOT ask more questions back
+
+Be helpful and direct. The founder needs closure, not more questions.`;
+  }
+
+  // Hard cap: after MAX + 3 more exchanges, be very firm
+  return `## CONVERSATION LIMIT — PROVIDE FINAL ANSWER
+This conversation has had ${exchangeCount} exchanges, which is well beyond the productive range. You MUST:
+1. Provide your FINAL concrete advice in this response
+2. List 3 specific action items the founder should take RIGHT NOW
+3. Do NOT ask any questions — this is your closing statement
+4. End with: "That should get you moving. Come back when you've made progress on these and we'll go deeper."
+
+This is non-negotiable. Give actionable advice and close the loop.`;
+}
 
 // ============================================================================
 // Platform Navigation Map
@@ -415,7 +453,7 @@ async function handlePost(req: NextRequest) {
       );
     }
 
-    const { message: rawMessage, context, sessionId, stream, storeInMemory, pageContext } = parsed.data;
+    const { message: rawMessage, context, sessionId, stream, storeInMemory, pageContext, exchangeCount } = parsed.data;
 
     // Prompt injection guard
     const injectionCheck = detectInjectionAttempt(rawMessage);
@@ -749,7 +787,11 @@ INSTRUCTIONS: When natural in conversation, check in on these. Ask "How did X go
       )
     }
 
+    // AI-8890: Loop-breaker — after N exchanges, tell FRED to wrap up
+    const loopBreakerBlock = buildLoopBreakerBlock(exchangeCount ?? 0);
+
     let fullContext = [
+      loopBreakerBlock,    // AI-8890: Loop-breaker takes highest priority when active
       stageRedirectBlock,  // Phase 80: Stage-gate redirect (highest priority when active)
       stageAwareBlock,     // Phase 80: Always-on stage awareness + proactive guidance
       founderContext,

--- a/components/chat/chat-input.tsx
+++ b/components/chat/chat-input.tsx
@@ -129,7 +129,7 @@ export function ChatInput({ onSend, isLoading = false, placeholder = "Ask Fred a
       </AnimatePresence>
 
       {/* Glassmorphism container */}
-      <div className="relative backdrop-blur-xl bg-white/10 border border-white/20 rounded-2xl shadow-2xl">
+      <div className="relative backdrop-blur-xl bg-white/15 dark:bg-white/10 border border-gray-300/30 dark:border-white/25 rounded-2xl shadow-2xl">
         {/* Gradient glow effect */}
         <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-primary/20 via-blue-500/20 to-purple-500/20 blur-xl opacity-50 -z-10" />
 
@@ -188,7 +188,7 @@ export function ChatInput({ onSend, isLoading = false, placeholder = "Ask Fred a
             aria-label="Message to Fred"
             className={cn(
               "flex-1 bg-transparent border-0 outline-none resize-none",
-              "text-base text-foreground placeholder:text-muted-foreground/60",
+              "text-base text-foreground placeholder:text-muted-foreground/80",
               "max-h-32 min-h-[44px] py-2 px-1",
               "disabled:opacity-50 disabled:cursor-not-allowed"
             )}
@@ -222,7 +222,7 @@ export function ChatInput({ onSend, isLoading = false, placeholder = "Ask Fred a
         </div>
 
         {/* Typing hint — hidden on mobile */}
-        <div className="hidden sm:flex items-center justify-between px-4 pb-2 text-xs text-muted-foreground/60">
+        <div className="hidden sm:flex items-center justify-between px-4 pb-2 text-xs text-muted-foreground/80">
           <span>Press Enter to send, Shift+Enter for new line</span>
           {showVoiceInput && isSupported && (
             <span className="flex items-center gap-1">

--- a/components/chat/chat-interface.tsx
+++ b/components/chat/chat-interface.tsx
@@ -243,10 +243,10 @@ export function ChatInterface({ className, pageContext, initialMessage, onInitia
                 <h3 className="text-sm font-semibold text-[#ff6a1a] mb-2">
                   Welcome to Sahara
                 </h3>
-                <p className="text-sm text-foreground/80 leading-relaxed mb-3">
+                <p className="text-sm text-foreground/90 leading-relaxed mb-3">
                   Sahara is your AI-powered founder operating system. Your mentor Fred Cary has advised hundreds of companies, taken 2 public, and mentored hundreds of founders.
                 </p>
-                <div className="space-y-1.5 text-xs text-foreground/70">
+                <div className="space-y-1.5 text-xs text-foreground/80">
                   <p>Here&apos;s what to expect:</p>
                   <ul className="list-disc list-inside space-y-1 pl-1">
                     <li>Structured mentoring — Fred will guide you step by step</li>
@@ -266,8 +266,8 @@ export function ChatInterface({ className, pageContext, initialMessage, onInitia
                   onClick={() => handleSendMessage(chip)}
                   className={cn(
                     "text-xs px-3 py-1.5 rounded-full border",
-                    "bg-white/10 border-white/20 text-foreground/80",
-                    "hover:bg-[#ff6a1a]/10 hover:border-[#ff6a1a]/40 hover:text-[#ff6a1a]",
+                    "bg-white/15 border-white/30 text-foreground",
+                    "hover:bg-[#ff6a1a]/15 hover:border-[#ff6a1a]/50 hover:text-[#ff6a1a]",
                     "transition-all duration-200 cursor-pointer"
                   )}
                 >
@@ -282,8 +282,8 @@ export function ChatInterface({ className, pageContext, initialMessage, onInitia
       {/* Error banner with retry */}
       {error && (
         <div className="px-4 py-2">
-          <div className="max-w-4xl mx-auto flex items-center gap-3 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-3">
-            <div className="flex-1 text-sm text-red-400">
+          <div className="max-w-4xl mx-auto flex items-center gap-3 rounded-lg border border-red-500/40 bg-red-500/15 px-4 py-3">
+            <div className="flex-1 text-sm text-red-600 dark:text-red-300">
               Fred is having trouble responding. This is usually temporary.
             </div>
             <button
@@ -292,7 +292,7 @@ export function ChatInterface({ className, pageContext, initialMessage, onInitia
                 const lastUserMsg = fredMessages.filter(m => m.role === "user").pop();
                 if (lastUserMsg) sendMessage(lastUserMsg.content);
               }}
-              className="shrink-0 rounded-md bg-red-500/20 px-3 py-1.5 text-xs font-medium text-red-300 hover:bg-red-500/30 transition-colors"
+              className="shrink-0 rounded-md bg-red-500/20 px-3 py-1.5 text-xs font-medium text-red-700 dark:text-red-200 hover:bg-red-500/30 transition-colors"
             >
               Retry
             </button>
@@ -301,7 +301,7 @@ export function ChatInterface({ className, pageContext, initialMessage, onInitia
       )}
 
       {/* Input area */}
-      <div className="sticky bottom-0 p-4 pb-[max(1rem,env(safe-area-inset-bottom))] backdrop-blur-xl bg-background/80 border-t border-white/10">
+      <div className="sticky bottom-0 p-4 pb-[max(1rem,env(safe-area-inset-bottom))] backdrop-blur-xl bg-background/80 border-t border-gray-200/30 dark:border-white/15">
         <div className="max-w-4xl mx-auto">
           <ChatInput onSend={handleSendMessage} isLoading={isProcessing} showVoiceInput />
         </div>

--- a/components/chat/chat-message.tsx
+++ b/components/chat/chat-message.tsx
@@ -120,7 +120,7 @@ export function ChatMessage({
             "relative px-4 py-3 rounded-2xl shadow-lg group",
             isUser
               ? "bg-gradient-to-br from-[#ff6a1a] via-orange-500 to-amber-500 text-white rounded-tr-sm"
-              : "bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 rounded-tl-sm"
+              : "bg-white dark:bg-gray-800/90 border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-50 rounded-tl-sm"
           )}
         >
           {/* Glassmorphism glow effect for AI messages */}
@@ -150,11 +150,11 @@ export function ChatMessage({
             </p>
           ) : (
             <div className={cn(
-              "relative z-10 text-sm leading-relaxed text-gray-900 dark:text-gray-100",
+              "relative z-10 text-sm leading-relaxed text-gray-900 dark:text-gray-50",
               "prose prose-sm dark:prose-invert max-w-none",
-              "prose-headings:text-gray-900 dark:prose-headings:text-gray-100 prose-headings:font-semibold prose-headings:mt-3 prose-headings:mb-1",
+              "prose-headings:text-gray-900 dark:prose-headings:text-white prose-headings:font-semibold prose-headings:mt-3 prose-headings:mb-1",
               "prose-p:my-1.5 prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5",
-              "prose-strong:text-gray-900 dark:prose-strong:text-gray-100 prose-code:text-[#ff6a1a] prose-code:bg-gray-100 dark:prose-code:bg-gray-900 prose-code:px-1 prose-code:rounded",
+              "prose-strong:text-gray-900 dark:prose-strong:text-white prose-code:text-[#ff6a1a] prose-code:bg-gray-100 dark:prose-code:bg-gray-900 prose-code:px-1 prose-code:rounded",
             )}>
               <ReactMarkdown>{message.isStreaming ? cleanStreamingMarkdown(message.content) : message.content}</ReactMarkdown>
               {message.isStreaming && (

--- a/lib/hooks/use-fred-chat.ts
+++ b/lib/hooks/use-fred-chat.ts
@@ -334,6 +334,8 @@ export function useFredChat(options: UseFredChatOptions = {}): UseFredChatReturn
         if (mountedRef.current) {
           setMessages(hydrated);
           hydratedSessionIdRef.current = targetSessionId;
+          // AI-8890: Sync exchange count from hydrated messages
+          exchangeCountRef.current = hydrated.filter(m => m.role === "user").length;
         }
       } catch {
         // Non-blocking: empty chat is acceptable fallback
@@ -367,6 +369,9 @@ export function useFredChat(options: UseFredChatOptions = {}): UseFredChatReturn
   // Guard against rapid-fire duplicate submissions
   const sendingRef = useRef(false);
 
+  // AI-8890: Track user exchange count for loop-breaking
+  const exchangeCountRef = useRef(messages.filter(m => m.role === "user").length);
+
   // Send message with streaming
   const sendMessage = useCallback(async (content: string, options?: { source?: "text" | "voice" }) => {
     // Prevent rapid-fire: if we're already processing a send, ignore
@@ -391,6 +396,7 @@ export function useFredChat(options: UseFredChatOptions = {}): UseFredChatReturn
       source: options?.source,
     };
     setMessages(prev => [...prev, userMessage]);
+    exchangeCountRef.current += 1;
 
     // Reset state
     setState("connecting");
@@ -418,6 +424,7 @@ export function useFredChat(options: UseFredChatOptions = {}): UseFredChatReturn
           stream: true,
           storeInMemory,
           pageContext,
+          exchangeCount: exchangeCountRef.current,
         }),
         signal,
       });
@@ -814,6 +821,7 @@ export function useFredChat(options: UseFredChatOptions = {}): UseFredChatReturn
     setError(null);
     setRedFlags([]);
     setRateLimitInfo({ isRateLimited: false });
+    exchangeCountRef.current = 0;
 
     // Generate new session ID and clear persisted messages
     const newSessionId = crypto.randomUUID();


### PR DESCRIPTION
## Summary
- **Loop-breaker**: Tracks user exchange count per session and injects wrap-up instructions into FRED's system prompt after 8 exchanges, preventing the chatbot from endlessly asking follow-up questions without providing actionable advice
- **UI contrast**: Improves text/border opacity across chat components (suggestion chips, welcome card, input area, assistant messages, error banner) for better readability in both light and dark modes

## Changes
- `app/api/fred/chat/route.ts`: Add `exchangeCount` to request schema, `buildLoopBreakerBlock()` function with 2-tier escalation (soft wrap-up at 8, hard cap at 11), injected at highest priority in system context
- `lib/hooks/use-fred-chat.ts`: Track exchange count via ref, pass to API, sync on hydration/reset
- `components/chat/chat-interface.tsx`: Increase opacity on chips, welcome text, error banner; add light/dark border awareness
- `components/chat/chat-input.tsx`: Stronger placeholder/hint text, better input container borders
- `components/chat/chat-message.tsx`: Brighter dark-mode text (gray-50/white), stronger borders

## Testing
- All 14 `use-fred-chat.test.ts` tests pass
- All 16 `fred-machine.test.ts` tests pass
- TypeScript compiles clean (only pre-existing `.next/types` cache warnings)

Closes AI-8890

Linear: https://linear.app/ai-acrobatics/issue/AI-8890/sahara-fix-chatbot-infinite-loop-improve-ui-contrast