### PR TITLE
AI-8906: Password-reset email template + 404 fix for 65-user migration

### DIFF
--- a/app/api/admin/send-password-reset/route.ts
+++ b/app/api/admin/send-password-reset/route.ts
@@ -1,0 +1,148 @@
+/**
+ * Admin: Send branded password-reset email
+ *
+ * POST /api/admin/send-password-reset
+ * body: { email: string, variant?: "migration" | "self-serve", preview?: boolean }
+ *
+ * Generates a Supabase recovery link via the admin API (so the link is
+ * already valid without the user clicking through Supabase's plaintext
+ * email), wraps it in our branded React Email template, and sends through
+ * Resend.
+ *
+ * AI-8906: Sean asked for a sample template before mass-sending the
+ * 65-user migration cohort. With `?preview=true`, the endpoint renders
+ * the email HTML and returns it without sending — Sean reviews, then
+ * we run the same call with preview=false to actually send.
+ *
+ * Requires admin authentication.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminRequest } from "@/lib/auth/admin";
+import { createServiceClient } from "@/lib/supabase/server";
+import { sendEmail } from "@/lib/email/send";
+import PasswordResetEmail from "@/lib/email/templates/password-reset";
+import { render } from "@react-email/components";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  const denied = await requireAdminRequest(request);
+  if (denied) return denied;
+
+  try {
+    const body = await request.json();
+    const email = (body.email || "").toString().trim().toLowerCase();
+    const variant: "migration" | "self-serve" =
+      body.variant === "migration" ? "migration" : "self-serve";
+    const preview = body.preview === true;
+
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return NextResponse.json(
+        { error: "valid email required" },
+        { status: 400 }
+      );
+    }
+
+    const appUrl =
+      process.env.NEXT_PUBLIC_APP_URL || "https://www.joinsahara.com";
+
+    const supabase = createServiceClient();
+
+    // Look up the user — also pulls name for personalization
+    const { data: usersList } = await supabase.auth.admin.listUsers({
+      page: 1,
+      perPage: 200,
+    });
+    const authUser = usersList.users.find(
+      (u) => (u.email || "").toLowerCase() === email
+    );
+
+    let recipientName: string | null = null;
+    let resetUrl = `${appUrl}/forgot-password?email=${encodeURIComponent(email)}`;
+
+    if (authUser) {
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("name")
+        .eq("id", authUser.id)
+        .maybeSingle();
+      recipientName =
+        (profile as { name?: string } | null)?.name ?? null;
+
+      // Generate a real recovery link via Supabase admin API. This produces
+      // a token-bearing URL that bypasses Supabase's plaintext email entirely.
+      const { data: linkData, error: linkErr } =
+        await supabase.auth.admin.generateLink({
+          type: "recovery",
+          email,
+          options: {
+            redirectTo: `${appUrl}/api/auth/callback?next=/reset-password`,
+          },
+        });
+
+      if (linkErr) {
+        console.error(
+          "[admin/send-password-reset] generateLink error:",
+          linkErr
+        );
+      } else if (linkData?.properties?.action_link) {
+        resetUrl = linkData.properties.action_link;
+      }
+    }
+
+    const emailComponent = PasswordResetEmail({
+      recipientName,
+      resetUrl,
+      appUrl,
+      variant,
+      expiresInHours: 1,
+    });
+
+    if (preview) {
+      const html = await render(emailComponent);
+      return NextResponse.json({
+        preview: true,
+        html,
+        resetUrl,
+        recipientName,
+        variant,
+      });
+    }
+
+    const subject =
+      variant === "migration"
+        ? "Set your new Sahara password"
+        : "Reset your Sahara password";
+
+    const result = await sendEmail({
+      to: email,
+      subject,
+      react: emailComponent,
+      tags: [
+        { name: "category", value: "password-reset" },
+        { name: "variant", value: variant },
+      ],
+    });
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error ?? "send failed" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      email,
+      variant,
+      resend_id: result.resendId,
+    });
+  } catch (err) {
+    console.error("[admin/send-password-reset] error:", err);
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "send failed" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/reset/route.ts
+++ b/app/reset/route.ts
@@ -1,0 +1,47 @@
+/**
+ * /reset
+ *
+ * Short-link / fallback for password-reset emails (AI-8906).
+ *
+ * Some legacy reset emails sent before the 2026-04 platform consolidation
+ * pointed at /reset (or hash-based URLs) that returned 404 on the new
+ * platform. This route catches them and redirects to /reset-password
+ * with any token query/hash forwarded so the SDK can still consume them.
+ *
+ * Also accepts ?email= so we can deep-link directly into the
+ * forgot-password form when a user lands here without a token.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+export function GET(request: NextRequest) {
+  const { searchParams, origin } = request.nextUrl;
+  const tokenHash =
+    searchParams.get("token_hash") || searchParams.get("token");
+  const code = searchParams.get("code");
+  const email = searchParams.get("email");
+  const type = searchParams.get("type") ?? "recovery";
+
+  // PKCE flow ?code= -> /api/auth/callback exchanges, then -> /reset-password
+  if (code) {
+    const target = new URL("/api/auth/callback", origin);
+    target.searchParams.set("code", code);
+    target.searchParams.set("next", "/reset-password");
+    return NextResponse.redirect(target, 308);
+  }
+
+  // OTP/token_hash flow -> /auth/verify
+  if (tokenHash) {
+    const target = new URL("/auth/verify", origin);
+    target.searchParams.set("token_hash", tokenHash);
+    target.searchParams.set("type", type);
+    target.searchParams.set("next", "/reset-password");
+    return NextResponse.redirect(target, 308);
+  }
+
+  // No token. Either the user clicked an expired link or just typed /reset.
+  // Send them to forgot-password with the email pre-filled if known.
+  const target = new URL("/forgot-password", origin);
+  if (email) target.searchParams.set("email", email);
+  return NextResponse.redirect(target, 308);
+}

--- a/lib/auth/middleware-utils.ts
+++ b/lib/auth/middleware-utils.ts
@@ -44,6 +44,7 @@ export const DEFAULT_PUBLIC_ROUTES: PublicRouteConfig = {
     '/register',
     '/forgot-password',
     '/reset-password',
+    '/reset',
     '/pricing',
     '/about',
     '/product',
@@ -53,6 +54,7 @@ export const DEFAULT_PUBLIC_ROUTES: PublicRouteConfig = {
   ]),
   patterns: [
     /^\/api\/auth\//,
+    /^\/auth\//,  // /auth/verify et al — Supabase OTP flows
     /^\/_next\//,
     /^\/public\//,
     /\.json$|\.xml$|\.txt$/,

--- a/lib/email/templates/password-reset.tsx
+++ b/lib/email/templates/password-reset.tsx
@@ -1,0 +1,174 @@
+/**
+ * Password Reset Email Template (AI-8906)
+ *
+ * Sent to migrated users (and anyone using the forgot-password flow) so the
+ * email comes from Sahara's branded Resend sender instead of relying on
+ * Supabase's default plaintext SMTP. Body explains:
+ *   - Why they got it (account migrated from previous platform OR they
+ *     clicked "forgot password")
+ *   - What clicking the link does (sets a new password, takes them to the
+ *     login dashboard)
+ *   - That the link is single-use and expires in 1 hour
+ *
+ * Phase 65-user migration (2026-04-22 meeting): Sean Gelt and Fred Cary
+ * asked for a sample template before mass-sending so they could review
+ * tone + fields. This component renders that sample.
+ */
+
+import {
+  Heading,
+  Text,
+  Button,
+  Section,
+  Link,
+} from "@react-email/components";
+import { EmailLayout } from "./layout";
+
+export interface PasswordResetEmailProps {
+  /** Greeting name. Falls back to "there" when missing. */
+  recipientName?: string | null;
+  /** The signed magic link the user clicks to reset their password. */
+  resetUrl: string;
+  /** App base URL used by the layout footer (settings link). */
+  appUrl: string;
+  /** Variant — controls the contextual blurb at top. */
+  variant?: "migration" | "self-serve";
+  /** Hours until the link expires. Default 1. */
+  expiresInHours?: number;
+}
+
+export default function PasswordResetEmail({
+  recipientName,
+  resetUrl,
+  appUrl,
+  variant = "self-serve",
+  expiresInHours = 1,
+}: PasswordResetEmailProps) {
+  const greetingName = recipientName?.trim() || "there";
+  const previewText =
+    variant === "migration"
+      ? "Set your new Sahara password to access your account"
+      : "Reset your Sahara password";
+
+  return (
+    <EmailLayout previewText={previewText} appUrl={appUrl}>
+      <Heading
+        as="h1"
+        style={{
+          fontSize: "24px",
+          fontWeight: 700,
+          color: "#111827",
+          margin: "0 0 16px 0",
+          lineHeight: "32px",
+        }}
+      >
+        {variant === "migration"
+          ? "Welcome back to Sahara, " + greetingName
+          : "Reset your password, " + greetingName}
+      </Heading>
+
+      {variant === "migration" ? (
+        <>
+          <Text
+            style={{
+              fontSize: "16px",
+              color: "#374151",
+              lineHeight: "24px",
+              margin: "0 0 16px 0",
+            }}
+          >
+            We&apos;ve moved Sahara onto a new platform. Your account, profile, and
+            progress have been migrated &mdash; <strong>nothing has been lost</strong>. The
+            one thing we couldn&apos;t carry over is your password (it was encrypted
+            on the old platform), so we need you to set a new one before
+            signing in.
+          </Text>
+          <Text
+            style={{
+              fontSize: "16px",
+              color: "#374151",
+              lineHeight: "24px",
+              margin: "0 0 24px 0",
+            }}
+          >
+            Click the button below to set your new password. It only takes a
+            second.
+          </Text>
+        </>
+      ) : (
+        <Text
+          style={{
+            fontSize: "16px",
+            color: "#374151",
+            lineHeight: "24px",
+            margin: "0 0 24px 0",
+          }}
+        >
+          We received a request to reset your Sahara password. Click the button
+          below to choose a new one. If you didn&apos;t request this, you can safely
+          ignore this email &mdash; your password will stay the same.
+        </Text>
+      )}
+
+      <Section style={{ textAlign: "center" as const, margin: "0 0 32px 0" }}>
+        <Button
+          href={resetUrl}
+          style={{
+            backgroundColor: "#ff6a1a",
+            color: "#ffffff",
+            padding: "14px 32px",
+            borderRadius: "8px",
+            textDecoration: "none",
+            fontSize: "16px",
+            fontWeight: 600,
+            display: "inline-block",
+          }}
+        >
+          {variant === "migration" ? "Set my new password" : "Reset my password"}
+        </Button>
+      </Section>
+
+      <Text
+        style={{
+          fontSize: "14px",
+          color: "#6b7280",
+          lineHeight: "20px",
+          margin: "0 0 16px 0",
+        }}
+      >
+        <strong>Heads up:</strong> this link is single-use and expires in{" "}
+        {expiresInHours} hour{expiresInHours === 1 ? "" : "s"}. If it expires,
+        just request a new one from the{" "}
+        <Link
+          href={`${appUrl}/forgot-password`}
+          style={{ color: "#ff6a1a", textDecoration: "underline" }}
+        >
+          forgot-password page
+        </Link>
+        .
+      </Text>
+
+      <Text
+        style={{
+          fontSize: "14px",
+          color: "#9ca3af",
+          lineHeight: "20px",
+          margin: "16px 0 0 0",
+        }}
+      >
+        Button not working? Copy this link into your browser:
+        <br />
+        <Link
+          href={resetUrl}
+          style={{
+            color: "#6b7280",
+            wordBreak: "break-all",
+            fontSize: "12px",
+          }}
+        >
+          {resetUrl}
+        </Link>
+      </Text>
+    </EmailLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- New branded React Email template `lib/email/templates/password-reset.tsx` with `migration` and `self-serve` variants
- New admin endpoint `POST /api/admin/send-password-reset` that generates a real Supabase recovery link via admin API, wraps it in the branded template, and sends via Resend (supports `preview: true` for sample HTML review before mass-send)
- New `/reset` short-link route catches legacy reset URLs and forwards token/code/email to the proper handler — stops the 404s users were hitting
- Add `/reset` and `/auth/*` to public-routes list so middleware doesn't gate them

## Why
Sahara Founders meeting 2026-04-22: 65-user Firebase migration needs (1) a sample password-reset template Sean can review before mass-sending, and (2) a fix for the reset-link 404 some users were hitting.

## Acceptance criteria
- [x] Reset password link 404 errors fixed (`/reset` short-link + `/auth/*` public routes)
- [x] Sample password reset email template created (`PasswordResetEmail` with `migration` variant)
- [x] Admin endpoint to generate sample / send (`/api/admin/send-password-reset` with `preview: true`)

## Out of scope (tracked separately)
- DNS coordination with Alex — covered by AI-8874 / PR #209
- Internal status email — content work, Sean can compose using new endpoint

## Test plan
- [ ] `curl -X POST https://<preview>/api/admin/send-password-reset -d '{"email":"X","variant":"migration","preview":true}'` returns HTML
- [ ] Same call with `preview: false` actually sends via Resend
- [ ] Visit `/reset?code=abc` -> 308 redirect to `/api/auth/callback?code=abc&next=/reset-password`
- [ ] Visit `/reset?token_hash=abc&type=recovery` -> 308 to `/auth/verify?...`
- [ ] Visit `/reset` (no params) -> 308 to `/forgot-password`

Closes AI-8906.

Linear: https://linear.app/ai-acrobatics/issue/AI-8906

🤖 Generated with [Claude Code](https://claude.com/claude-code)