### PR TITLE
AI-8954: Strip dead u.joinsahara.com references

### DIFF
--- a/funnel/index.html
+++ b/funnel/index.html
@@ -15,10 +15,10 @@
 
     <!-- Open Graph / Social -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://u.joinsahara.com/" />
+    <meta property="og:url" content="https://you.joinsahara.com/" />
     <meta property="og:title" content="Sahara — Talk to Fred" />
     <meta property="og:description" content="AI-Powered Founder Operating System. Chat with Fred, explore the founder journey, and get startup answers — free." />
-    <meta property="og:image" content="https://u.joinsahara.com/icon-192.png" />
+    <meta property="og:image" content="https://you.joinsahara.com/icon-192.png" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Sahara — Talk to Fred" />
     <meta name="twitter:description" content="AI-Powered Founder Operating System. Chat with Fred, explore the founder journey, and get startup answers — free." />

--- a/funnel/src/lib/constants.ts
+++ b/funnel/src/lib/constants.ts
@@ -9,7 +9,7 @@ export const BRAND = {
   color: '#ff6a1a',
   colorHover: '#ea580c',
   url: 'https://joinsahara.com',
-  funnelUrl: 'https://u.joinsahara.com',
+  funnelUrl: 'https://you.joinsahara.com',
 } as const
 
 /**
@@ -31,7 +31,7 @@ Key traits:
 
 Keep responses concise (2-4 paragraphs max). Use conversational tone. If a founder seems stuck, ask clarifying questions. Always end with a clear next step or question.
 
-You're currently chatting on the Sahara lite funnel (u.joinsahara.com). If users ask about advanced features (pitch deck review, investor readiness, virtual team agents), let them know those are available on the full Sahara platform at joinsahara.com.`,
+You're currently chatting on the Sahara lite funnel (you.joinsahara.com). If users ask about advanced features (pitch deck review, investor readiness, virtual team agents), let them know those are available on the full Sahara platform at joinsahara.com.`,
 } as const
 
 /**

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,30 +38,17 @@ export async function middleware(request: NextRequest) {
   const origin = request.headers.get("origin");
 
   // ---------------------------------------------------------------------
-  // you.joinsahara.com / u.joinsahara.com deprecation (2026-04-22). The
-  // legacy Firebase-backed funnel subdomain (hosted on a separate Vercel
-  // project serving the Vite funnel app) is consolidated onto the permanent
-  // platform. Any request arriving with either legacy host header is
-  // 308-redirected to the equivalent path on www.joinsahara.com, with a
-  // ?from=funnel-migration flag so the landing page can show a one-time
-  // "welcome back" banner (see components/welcome-back-banner.tsx).
-  //
-  // u.joinsahara.com is included alongside you.joinsahara.com because both
-  // appear historically in the changelog, the Vite funnel app's og:url, the
-  // QR-code targets in the founder PRD, and external collateral (WhatsApp
-  // shares, decks). Keeping both supported costs nothing and prevents
-  // referrers landing on a dead host if u.joinsahara.com ever gets DNS.
-  //
-  // NOTE: this middleware only fires once the legacy host is pointed at
-  // THIS Vercel project. Until the domain is moved (or DNS is flipped)
-  // this block is defensive / a no-op.
+  // you.joinsahara.com host-redirect: when the legacy funnel subdomain is
+  // pointed at this Vercel project, requests are 308-redirected to the
+  // equivalent path on www.joinsahara.com with a ?from=funnel-migration
+  // flag so the landing page can show a one-time "welcome back" banner
+  // (see components/welcome-back-banner.tsx). Defensive / a no-op until
+  // DNS for you.joinsahara.com is moved to this project.
   // ---------------------------------------------------------------------
   const host = (request.headers.get("host") || "").toLowerCase();
   if (
     host === "you.joinsahara.com" ||
-    host.startsWith("you.joinsahara.com:") ||
-    host === "u.joinsahara.com" ||
-    host.startsWith("u.joinsahara.com:")
+    host.startsWith("you.joinsahara.com:")
   ) {
     const target = new URL(pathname, "https://www.joinsahara.com");
     // Preserve the original query string.


### PR DESCRIPTION
There is no such domain as u.joinsahara.com — the legacy funnel subdomain is you.joinsahara.com.

The defensive u. middleware block (added in PR #209 / AI-8874) and the stale u. references in the Vite funnel app were dead code. Removing them so future agents don't re-introduce u. anywhere.

## Changes

- **middleware.ts** — drop u.joinsahara.com from the host-redirect block, tighten the comment.
- **funnel/index.html** — og:url + og:image now point at you.joinsahara.com.
- **funnel/src/lib/constants.ts** — funnelUrl + Fred system prompt now reference you.joinsahara.com.

## Verification

- All CTAs on prod (homepage, /pricing, /features) already point to https://you.joinsahara.com (shipped in PR #209).
- Live you.joinsahara.com already serves og:url=you.joinsahara.com via the deployed funnel asset.
- u.joinsahara.com has no DNS — no prod behavior change.
- `grep -rnE "u\.joinsahara"` against `app/`, `components/`, `funnel/`, `middleware.ts`, `lib/` returns no matches that aren't `you.joinsahara`.

Linear: AI-8954