### PR TITLE
AI-8874: redirect joinsahara.com + www to you.joinsahara.com

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,7 +28,7 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "https://joinsahara.com"),
+  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || "https://you.joinsahara.com"),
   title: "Sahara | AI-Powered Founder Operating System",
   description: "Think Clearer. Raise Smarter. Scale Faster. Sahara is the AI-powered operating system for startup founders. Built by Fred Cary — hundreds of founders coached, $3B+ raised.",
   keywords: ["startup", "founder", "fundraising", "investor", "pitch deck", "venture capital", "AI", "Sahara", "Fred Cary"],

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
   const baseUrl =
-    process.env.NEXT_PUBLIC_APP_URL || "https://joinsahara.com";
+    process.env.NEXT_PUBLIC_APP_URL || "https://you.joinsahara.com";
 
   return {
     rules: [

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl =
-    process.env.NEXT_PUBLIC_APP_URL || "https://joinsahara.com";
+    process.env.NEXT_PUBLIC_APP_URL || "https://you.joinsahara.com";
   const now = new Date();
 
   return [

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,35 +38,41 @@ export async function middleware(request: NextRequest) {
   const origin = request.headers.get("origin");
 
   // ---------------------------------------------------------------------
-  // you.joinsahara.com host-redirect: when the legacy funnel subdomain is
-  // pointed at this Vercel project, requests are 308-redirected to the
-  // equivalent path on www.joinsahara.com with a ?from=funnel-migration
-  // flag so the landing page can show a one-time "welcome back" banner
-  // (see components/welcome-back-banner.tsx). Defensive / a no-op until
-  // DNS for you.joinsahara.com is moved to this project.
+  // joinsahara.com / www.joinsahara.com host-redirect to you.joinsahara.com.
+  // Per Julian: Alex LaTorre's Vite + Firebase build at you.joinsahara.com is
+  // the public face of Sahara going forward. This legacy Next.js dashboard is
+  // being deprecated — until Alex's Vercel project claims joinsahara.com +
+  // www.joinsahara.com as aliases, this middleware bounces inbound apex/www
+  // traffic over to his app.
+  //
+  // Path allowlist: /api/*, /auth/*, /_next/* and the favicon are NOT
+  // redirected. External callers (Stripe webhooks, Supabase auth callbacks,
+  // OAuth providers) hit those paths and a 302 to a different host would
+  // break webhook delivery + auth flows. Asset paths (_next/*) skip the
+  // bounce so any cached HTML still renders.
+  //
+  // 302 (temporary) is intentional: once Alex claims the aliases this block
+  // becomes circular and gets removed. Permanent 308 would prematurely
+  // poison Google's index against the apex.
   // ---------------------------------------------------------------------
   const host = (request.headers.get("host") || "").toLowerCase();
-  if (
-    host === "you.joinsahara.com" ||
-    host.startsWith("you.joinsahara.com:")
-  ) {
-    const target = new URL(pathname, "https://www.joinsahara.com");
-    // Preserve the original query string.
+  const isLegacyApex =
+    host === "joinsahara.com" ||
+    host === "www.joinsahara.com" ||
+    host.startsWith("joinsahara.com:") ||
+    host.startsWith("www.joinsahara.com:");
+  const isInfraPath =
+    pathname.startsWith("/api/") ||
+    pathname.startsWith("/auth/") ||
+    pathname.startsWith("/_next/") ||
+    pathname === "/favicon.ico" ||
+    pathname === "/sitemap.xml" ||
+    pathname === "/robots.txt";
+
+  if (isLegacyApex && !isInfraPath) {
+    const target = new URL(pathname, "https://you.joinsahara.com");
     request.nextUrl.searchParams.forEach((v, k) => target.searchParams.set(k, v));
-
-    // Path-level remapping for routes that changed names on the new app.
-    if (pathname === "/signup" || pathname === "/") {
-      target.pathname = "/get-started";
-    } else if (pathname === "/login") {
-      target.searchParams.set("migrated", "1");
-    }
-
-    // Always stamp the migration flag so the banner renders once.
-    if (!target.searchParams.has("from")) {
-      target.searchParams.set("from", "funnel-migration");
-    }
-
-    return NextResponse.redirect(target, 308);
+    return NextResponse.redirect(target, 302);
   }
 
   // Phase 25-02: Correlation ID for structured logging


### PR DESCRIPTION
## Summary
- Bounces inbound traffic on `joinsahara.com` and `www.joinsahara.com` to `https://you.joinsahara.com<same path>` so the legacy Next.js dashboard stops being the public face of Sahara before Alex finishes claiming the aliases on his Vercel project.
- Replaces this morning's `you.joinsahara.com -> www.joinsahara.com` block (which never activated — different Vercel project owns that subdomain) with the inverse direction.
- `app/sitemap.ts`, `app/robots.ts`, `app/layout.tsx` env-var fallbacks now point at `https://you.joinsahara.com` so local-dev canonical URLs match. Production reads `NEXT_PUBLIC_APP_URL` from Vercel env, unchanged.

## Behavior

| Inbound | Result |
|---|---|
| `https://joinsahara.com/pricing` | `302 -> https://you.joinsahara.com/pricing` |
| `https://www.joinsahara.com/` | `302 -> https://you.joinsahara.com/` |
| `https://joinsahara.com/api/webhooks/stripe` | served by legacy app (NOT redirected) |
| `https://www.joinsahara.com/auth/callback` | served by legacy app (NOT redirected) |
| `https://you.joinsahara.com/...` | unchanged (Alex's project) |

Path allowlist excludes `/api/*`, `/auth/*`, `/_next/*`, `/favicon.ico`, `/sitemap.xml`, `/robots.txt` so Stripe webhooks, Supabase auth callbacks, OAuth providers, and asset URLs still hit the legacy backend.

302 (temporary) on purpose: once Alex claims `joinsahara.com` + `www.joinsahara.com` as aliases on his Vercel project, this redirect becomes circular and gets removed in a follow-up PR. A 308 would prematurely poison Google's index against the apex.

## Known transition cost
Anyone currently logged into the legacy dashboard gets bounced to `you.joinsahara.com` mid-session and would have to re-auth on Alex's app. That's the explicit cost of cutting over now vs. waiting on the alias swap. Per Julian, accepted.

## Test plan
- [ ] Vercel prod deploy READY on the merge SHA
- [ ] `curl -sI https://www.joinsahara.com/pricing` returns `302` with `Location: https://you.joinsahara.com/pricing`
- [ ] `curl -sI https://joinsahara.com/` 308s to `www`, then 302s to `you`
- [ ] `curl -sI https://www.joinsahara.com/api/health` returns 200 from the legacy app (NOT redirected)
- [ ] `curl -sI https://you.joinsahara.com/` still 200 from Alex's project (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)