### PR TITLE
fix(repo): AI-7367 sync checklist progress score

### DIFF
--- a/app/api/oases/progress/route.ts
+++ b/app/api/oases/progress/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
-import { getUserOasesProgress, getDetailedProgress } from "@/lib/oases/progress"
+import {
+  getUserOasesProgress,
+  getDetailedProgress,
+  resolveJourneyPercentage,
+} from "@/lib/oases/progress"
 
 /**
  * GET /api/oases/progress
@@ -28,11 +32,15 @@ export async function GET() {
       getDetailedProgress(user.id),
     ])
 
-    // Use the detailed journey_steps-based percentage for the overall number
-    // while keeping checklist data (completedStepIds, stepsCompleted/Total) for the UI
+    // Keep the displayed percentage in sync with the visible checklist. The
+    // granular journey_steps score can lag behind imported/completed checklist
+    // data, so it should never under-report checklist completion.
     const enrichedProgress = {
       ...progress,
-      journeyPercentage: detailed.journeyPercentage,
+      journeyPercentage: resolveJourneyPercentage(
+        progress.journeyPercentage,
+        detailed.journeyPercentage
+      ),
     }
 
     return NextResponse.json(

--- a/lib/oases/__tests__/progress.test.ts
+++ b/lib/oases/__tests__/progress.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+import { computeJourneyPercentage, resolveJourneyPercentage } from "../progress"
+
+describe("Oases progress calculation", () => {
+  it("calculates checklist completion from completed and total steps", () => {
+    expect(computeJourneyPercentage(19, 19)).toBe(100)
+    expect(computeJourneyPercentage(0, 0)).toBe(0)
+  })
+
+  it("does not let detailed journey progress under-report a completed checklist", () => {
+    expect(resolveJourneyPercentage(100, 75)).toBe(100)
+  })
+
+  it("keeps a higher granular journey score when it is ahead of the checklist", () => {
+    expect(resolveJourneyPercentage(80, 95)).toBe(95)
+  })
+})

--- a/lib/oases/progress.ts
+++ b/lib/oases/progress.ts
@@ -21,6 +21,22 @@ export function computeJourneyPercentage(
 }
 
 /**
+ * Resolve the displayed journey percentage when both progress systems are available.
+ *
+ * The Oases checklist drives the visible "N/N complete" UI, while older
+ * journey_steps data can lag behind it. To avoid showing impossible states like
+ * "19/19 complete" with a 75% score, never let the granular score under-report
+ * the checklist-derived completion.
+ */
+export function resolveJourneyPercentage(
+  checklistPercentage: number,
+  detailedPercentage?: number
+): number {
+  if (detailedPercentage == null) return checklistPercentage
+  return Math.max(checklistPercentage, detailedPercentage)
+}
+
+/**
  * Get detailed progress from the journey_steps table.
  * Returns per-stage step counts from the granular 120-step journey_steps table
  * and completed counts from oases_progress. Used for the progress percentage bar.


### PR DESCRIPTION
## Summary
- keep Oases progress percentage from under-reporting the visible checklist completion
- preserve granular journey progress when it is ahead of checklist progress
- add regression coverage for the 19/19 checklist + 75% score case

## Test
- npm test -- lib/oases/__tests__/progress.test.ts
- npx eslint app/api/oases/progress/route.ts lib/oases/progress.ts lib/oases/__tests__/progress.test.ts